### PR TITLE
Compile in gson for android modules

### DIFF
--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -53,6 +53,7 @@ android {
 dependencies {
     compile "com.noveogroup.android:android-logger:$android_logger_ver"
     compile "com.optimizely.ab:core-api:$java_core_ver"
+    compile "com.google.code.gson:gson:$gson_ver"
     provided "com.android.support:support-annotations:$support_annotations_ver"
 
     testCompile "junit:junit:$junit_ver"

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     // Includes SST Java core, event handler, and user experiment record
     compile project(':android-sdk')
 //    compile 'com.optimizely.ab:android-sdk:0.0.1'
-    compile "com.google.code.gson:gson:$gson_ver"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 


### PR DESCRIPTION
Per @jprovine we should just compile in the gson dependency for android devs using the module.  This doesn't affect the Java core.  It still requires the user to compile in their own gson parser.

Android users can still use Gradle to exclude gson if they don't want it.
