### PR TITLE
Handles running on ancient Android devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Tests can be run by right clicking the file in the project pane or by clicking t
 
 ## Releasing
 
-The default branch is devel.  Feature branch PRs are automatically made against it. When PRs are reviewed and pass checks they should be squased and merged into devel.  The version of the SDK in devel should always be the version of the next release plus `-SNAPSHOT`.  
+The default branch is devel.  Feature branch PRs are automatically made against it. When PRs are reviewed and pass checks they should be squashed and merged into devel.  The version of the SDK in devel should always be the version of the next release plus `-SNAPSHOT`.  
 
 If a beta, or snapshot, build needs to be published simply checkout beta and merge devel.  The beta branch should fast forward.  Push devel and Travis will start.  If the tests pass the build will be sent to our Maven repos on Bintray.  
 
-When a release version needs to be published checkout the master branch and merge devel.  The master branch should be fast forwared.  Remove the `-SNAPSHOT` from the version in `build.gradle` and commit directly onto master. Push master and if the tests pass Travis will publish the version to our Maven repos on Bintray.  if the version already exists on Bintray the upload will be rejected.  The commit that updates the version should also be tagged with the version number.
+When a release version needs to be published checkout the master branch and merge devel.  The master branch should be fast forwarded.  Remove the `-SNAPSHOT` from the version in `build.gradle` and commit directly onto master. Push master and if the tests pass Travis will publish the version to our Maven repos on Bintray.  if the version already exists on Bintray the upload will be rejected.  The commit that updates the version should also be tagged with the version number.
 
 Once the next release has been published from the master branch the snapshot version in devel should be bumped to the next targeted version.
 

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/DatafileServiceTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/DatafileServiceTest.java
@@ -17,7 +17,9 @@ package com.optimizely.ab.android.sdk;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.IBinder;
+import android.support.annotation.RequiresApi;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.ServiceTestRule;
 
@@ -42,6 +44,7 @@ public class DatafileServiceTest {
     @Rule
     public final ServiceTestRule mServiceRule = new ServiceTestRule();
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     @Ignore
     public void testBinding() throws TimeoutException {
@@ -56,6 +59,7 @@ public class DatafileServiceTest {
         assertTrue(dataFileService.isBound());
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     @Ignore
     public void testValidStart() throws TimeoutException {
@@ -70,6 +74,7 @@ public class DatafileServiceTest {
         verify(logger).info("Started watching project {} in the background", "1");
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void testNullIntentStart() throws TimeoutException {
         Context context = InstrumentationRegistry.getTargetContext();
@@ -82,6 +87,7 @@ public class DatafileServiceTest {
         verify(logger).warn("Data file service received a null intent");
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     @Ignore
     public void testNoProjectIdIntentStart() throws TimeoutException {

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerTest.java
@@ -17,6 +17,8 @@ package com.optimizely.ab.android.sdk;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 import android.support.test.espresso.core.deps.guava.util.concurrent.ListeningExecutorService;
 import android.support.test.espresso.core.deps.guava.util.concurrent.MoreExecutors;
 import android.support.test.runner.AndroidJUnit4;
@@ -109,6 +111,7 @@ public class OptimizelyManagerTest {
         verify(appContext).unbindService(dataFileServiceConnection);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void injectOptimizely() {
         Context context = mock(Context.class);
@@ -130,6 +133,7 @@ public class OptimizelyManagerTest {
         verify(startListener).onStart(any(AndroidOptimizely.class));
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void injectOptimizelyNullListener() {
         Context context = mock(Context.class);
@@ -154,6 +158,7 @@ public class OptimizelyManagerTest {
         assertEquals(optimizelyManager.getProjectId(), intent.getStringExtra(DataFileService.EXTRA_PROJECT_ID));
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void injectOptimizelyHandlesInvalidDataFile() {
         Context context = mock(Context.class);
@@ -178,6 +183,7 @@ public class OptimizelyManagerTest {
         assertEquals(optimizelyManager.getProjectId(), intent.getStringExtra(DataFileService.EXTRA_PROJECT_ID));
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void injectOptimizelyDoesNotDuplicateCallback() {
         Context context = mock(Context.class);
@@ -209,9 +215,4 @@ public class OptimizelyManagerTest {
 
         verify(logger).info("No listener to send Optimizely to");
     }
-
-//    @Test
-//    public void getOptimizelyFromCompiledDataFile() {
-//
-//    }
 }

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/DataFileLoader.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/DataFileLoader.java
@@ -17,8 +17,10 @@
 package com.optimizely.ab.android.sdk;
 
 import android.os.AsyncTask;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 
 import com.optimizely.ab.android.shared.Cache;
 import com.optimizely.ab.android.shared.Client;
@@ -44,6 +46,7 @@ class DataFileLoader {
         this.taskChain = taskChain;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     boolean getDataFile(@NonNull String projectId, @Nullable DataFileLoadedListener dataFileLoadedListener) {
         taskChain.start(projectId, dataFileLoadedListener);
 
@@ -62,6 +65,7 @@ class DataFileLoader {
             this.executor = Executors.newSingleThreadExecutor();
         }
 
+        @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
         void start(@NonNull String projectId, @Nullable DataFileLoadedListener dataFileLoadedListener) {
             DataFileClient dataFileClient = new DataFileClient(
                     new Client(new OptlyStorage(dataFileService), LoggerFactory.getLogger(OptlyStorage.class)),

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/DataFileService.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/DataFileService.java
@@ -19,8 +19,10 @@ package com.optimizely.ab.android.sdk;
 import android.app.Service;
 import android.content.Intent;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
 
 import com.optimizely.ab.android.shared.Cache;
 
@@ -42,6 +44,7 @@ public class DataFileService extends Service {
      * @hide
      * @see Service#onStartCommand(Intent, int, int)
      */
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         if (intent != null) {
@@ -93,6 +96,7 @@ public class DataFileService extends Service {
         stopSelf();
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     void getDataFile(String projectId, DataFileLoader dataFileLoader, DataFileLoadedListener loadedListener) {
         dataFileLoader.getDataFile(projectId, loadedListener);
     }

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/DataFileLoaderTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/DataFileLoaderTest.java
@@ -15,6 +15,9 @@
  */
 package com.optimizely.ab.android.sdk;
 
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -129,6 +132,7 @@ public class DataFileLoaderTest {
         verify(dataFileLoadedListener, never()).onDataFileLoaded(any(String.class));
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void getDataFile() {
         DataFileLoader.TaskChain taskChain = mock(DataFileLoader.TaskChain.class);

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerDataFileServiceConnectionTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerDataFileServiceConnectionTest.java
@@ -16,6 +16,8 @@
 package com.optimizely.ab.android.sdk;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 
 import com.optimizely.ab.android.shared.ServiceScheduler;
 import com.optimizely.user_experiment_record.AndroidUserExperimentRecord;
@@ -50,6 +52,7 @@ public class OptimizelyManagerDataFileServiceConnectionTest {
         dataFileServiceConnection = new OptimizelyManager.DataFileServiceConnection(optimizelyManager);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void onServiceConnected() {
         DataFileService.LocalBinder binder = mock(DataFileService.LocalBinder.class);
@@ -66,6 +69,7 @@ public class OptimizelyManagerDataFileServiceConnectionTest {
         verify(optimizelyManager).injectOptimizely(any(Context.class), any(AndroidUserExperimentRecord.class), any(ServiceScheduler.class), eq(""));
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void onServiceConnectedNotBoundWhenDataFileLoaded() {
         DataFileService.LocalBinder binder = mock(DataFileService.LocalBinder.class);
@@ -86,6 +90,7 @@ public class OptimizelyManagerDataFileServiceConnectionTest {
         verify(optimizelyManager, never()).injectOptimizely(any(Context.class), any(AndroidUserExperimentRecord.class), any(ServiceScheduler.class), eq(""));
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void onServiceConnectedNullServiceFromBinder() {
         DataFileService.LocalBinder binder = mock(DataFileService.LocalBinder.class);

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerOptlyActivityLifecycleCallbacksTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerOptlyActivityLifecycleCallbacksTest.java
@@ -16,6 +16,8 @@
 package com.optimizely.ab.android.sdk;
 
 import android.app.Activity;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -35,11 +37,13 @@ public class OptimizelyManagerOptlyActivityLifecycleCallbacksTest {
     @Mock Activity activity;
     private OptimizelyManager.OptlyActivityLifecycleCallbacks optlyActivityLifecycleCallbacks;
 
+    @RequiresApi(api = Build.VERSION_CODES.ICE_CREAM_SANDWICH)
     @Before
     public void setup() {
         optlyActivityLifecycleCallbacks = new OptimizelyManager.OptlyActivityLifecycleCallbacks(optimizelyManager);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.ICE_CREAM_SANDWICH)
     @Test
     public void onActivityStopped() {
         optlyActivityLifecycleCallbacks.onActivityStopped(activity);

--- a/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDAOTest.java
+++ b/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDAOTest.java
@@ -17,6 +17,8 @@
 package com.optimizely.ab.android.event_handler;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Pair;
@@ -47,6 +49,7 @@ public class EventDAOTest {
     private Logger logger;
     private Context context;
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Before
     public void setupEventDAO() {
         logger = mock(Logger.class);

--- a/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDispatcherTest.java
+++ b/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDispatcherTest.java
@@ -18,6 +18,8 @@ package com.optimizely.ab.android.event_handler;
 import android.app.AlarmManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -59,6 +61,7 @@ public class EventDispatcherTest {
     private Context context;
     private Client client;
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Before
     public void setup() {
         context = InstrumentationRegistry.getTargetContext();

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventDAO.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventDAO.java
@@ -19,7 +19,9 @@ package com.optimizely.ab.android.event_handler;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
 import android.util.Pair;
 
 import org.slf4j.Logger;
@@ -43,6 +45,7 @@ class EventDAO {
         this.logger = logger;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     static EventDAO getInstance(@NonNull Context context, @NonNull Logger logger) {
         EventSQLiteOpenHelper sqLiteOpenHelper = new EventSQLiteOpenHelper(context, EventSQLiteOpenHelper.DB_NAME, null, EventSQLiteOpenHelper.VERSION, null, LoggerFactory.getLogger(EventSQLiteOpenHelper.class));
         return new EventDAO(sqLiteOpenHelper, logger);

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventIntentService.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventIntentService.java
@@ -19,7 +19,9 @@ package com.optimizely.ab.android.event_handler;
 import android.app.AlarmManager;
 import android.app.IntentService;
 import android.content.Intent;
+import android.os.Build;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 
 import com.optimizely.ab.android.shared.Client;
 import com.optimizely.ab.android.shared.OptlyStorage;
@@ -53,6 +55,7 @@ public class EventIntentService extends IntentService {
      * @hide
      * @see IntentService#onCreate()
      */
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Override
     public void onCreate() {
         super.onCreate();

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventSQLiteOpenHelper.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventSQLiteOpenHelper.java
@@ -20,6 +20,8 @@ import android.content.Context;
 import android.database.DatabaseErrorHandler;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 
 import org.slf4j.Logger;
 
@@ -48,6 +50,7 @@ class EventSQLiteOpenHelper extends SQLiteOpenHelper {
         this.logger = logger;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     EventSQLiteOpenHelper(Context context, String name, SQLiteDatabase.CursorFactory factory, int version, DatabaseErrorHandler errorHandler, Logger logger) {
         super(context, name, factory, version, errorHandler);
         this.logger = logger;

--- a/shared/src/main/java/com/optimizely/ab/android/shared/Client.java
+++ b/shared/src/main/java/com/optimizely/ab/android/shared/Client.java
@@ -64,7 +64,7 @@ public class Client {
     }
 
     /**
-     * Adds a if-modfied-since header to the open {@link URLConnection} if this value is
+     * Adds a if-modified-since header to the open {@link URLConnection} if this value is
      * stored in {@link OptlyStorage}.
      * @param urlConnection an open {@link URLConnection}
      * @hide
@@ -77,7 +77,7 @@ public class Client {
     }
 
     /**
-     * Retrieves the last-modfied head from a {@link URLConnection} and saves it
+     * Retrieves the last-modified head from a {@link URLConnection} and saves it
      * in {@link OptlyStorage}.
      * @param urlConnection a {@link URLConnection} instance
      * @hide

--- a/shared/src/main/java/com/optimizely/ab/android/shared/OptlyStorage.java
+++ b/shared/src/main/java/com/optimizely/ab/android/shared/OptlyStorage.java
@@ -54,7 +54,7 @@ public class OptlyStorage {
     /**
      * Get a long value
      * @param key a String key
-     * @param defaultValue the value to return if the key isn't storedj
+     * @param defaultValue the value to return if the key isn't stored
      * @return the long value
      * @hide
      */

--- a/test-app/src/main/java/com/optimizely/ab/android/test_app/SecondaryActivity.java
+++ b/test-app/src/main/java/com/optimizely/ab/android/test_app/SecondaryActivity.java
@@ -15,10 +15,10 @@
  */
 package com.optimizely.ab.android.test_app;
 
-import android.app.Fragment;
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 
 import com.optimizely.ab.android.sdk.AndroidOptimizely;
@@ -38,7 +38,7 @@ public class SecondaryActivity extends AppCompatActivity {
         // track conversion event
         optimizely.track("goal_1", "user_1");
 
-        FragmentManager fragmentManager = getFragmentManager();
+        FragmentManager fragmentManager = getSupportFragmentManager();
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
 
         SecondaryFragment secondaryFragment = new SecondaryFragment();

--- a/user-experiment-record/src/androidTest/java/com/optimizely/user_experiment_record/WriteThroughCacheFactoryTest.java
+++ b/user-experiment-record/src/androidTest/java/com/optimizely/user_experiment_record/WriteThroughCacheFactoryTest.java
@@ -15,7 +15,9 @@
  */
 package com.optimizely.user_experiment_record;
 
+import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.core.deps.guava.util.concurrent.ListeningExecutorService;
 import android.support.test.espresso.core.deps.guava.util.concurrent.MoreExecutors;
@@ -58,6 +60,7 @@ public class WriteThroughCacheFactoryTest {
         logger = mock(Logger.class);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void startWriteCacheTask() throws JSONException {
         Cache cache = new Cache(InstrumentationRegistry.getTargetContext(), logger);
@@ -89,6 +92,7 @@ public class WriteThroughCacheFactoryTest {
         cache.delete(diskUserExperimentRecordCache.getFileName());
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void startWriteCacheTaskFail() throws JSONException, IOException {
         Cache cache = mock(Cache.class);
@@ -116,6 +120,7 @@ public class WriteThroughCacheFactoryTest {
         verify(logger).error("Failed to persist user in variation {} for experiment {}.", "var1", "exp1");
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void startRemoveCacheTask() throws JSONException, IOException {
         Cache cache = new Cache(InstrumentationRegistry.getTargetContext(), logger);
@@ -146,6 +151,7 @@ public class WriteThroughCacheFactoryTest {
         verify(logger).info("Removed experimentKey: {} variationKey: {} record for user: {} from disk", "exp1", "var1", "user1");
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void startRemoveCacheTaskFail() throws JSONException, IOException {
         Cache cache = mock(Cache.class);

--- a/user-experiment-record/src/main/java/com/optimizely/user_experiment_record/AndroidUserExperimentRecord.java
+++ b/user-experiment-record/src/main/java/com/optimizely/user_experiment_record/AndroidUserExperimentRecord.java
@@ -18,8 +18,10 @@ package com.optimizely.user_experiment_record;
 
 import android.content.Context;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 import android.util.Pair;
 
 import com.optimizely.ab.android.shared.Cache;
@@ -42,7 +44,7 @@ import java.util.concurrent.Executors;
  * Makes bucketing sticky.  This module is what allows the core
  * to know if a user has already been bucketed for an experiment.
  * Once a user is bucketed they will stay bucketed unless the device's
- * storage is cleared. Bucketting information is stored in a simple file.
+ * storage is cleared. Bucketing information is stored in a simple file.
  */
 public class AndroidUserExperimentRecord implements UserExperimentRecord {
 
@@ -110,6 +112,7 @@ public class AndroidUserExperimentRecord implements UserExperimentRecord {
     /**
      * @see UserExperimentRecord#save(String, String, String)
      */
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Override
     public boolean save(final String userId, final String experimentKey, final String variationKey) {
         if (userId == null) {
@@ -169,6 +172,7 @@ public class AndroidUserExperimentRecord implements UserExperimentRecord {
     /**
      * @see UserExperimentRecord#remove(String, String)
      */
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Override
     public boolean remove(final String userId, final String experimentKey) {
         if (userId == null) {
@@ -222,6 +226,7 @@ public class AndroidUserExperimentRecord implements UserExperimentRecord {
             return memoryUserExperimentRecordCache;
         }
 
+        @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
         void startWriteCacheTask(final String userId, final String experimentKey, final String variationKey) {
             AsyncTask<Void,Void,Boolean> task = new AsyncTask<Void, Void, Boolean>() {
                 @Override
@@ -255,6 +260,7 @@ public class AndroidUserExperimentRecord implements UserExperimentRecord {
             task.executeOnExecutor(executor);
         }
 
+        @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
         void startRemoveCacheTask(final String userId, final String experimentKey, final String variationKey) {
             AsyncTask<String, Void, Pair<String, Boolean>> task =  new AsyncTask<String, Void, Pair<String, Boolean>>() {
 


### PR DESCRIPTION
- Fixes typos
- Adds api level annotations to SDK methods
- Makes test app and android modules compile time min sdk 10
- Adds runtime check to to no-op and log if Android api is less than 14
- Tested on a API 10 emulator
- Can't really be tested without excessive wrapping of Build.VERSION.SDK_INIT
