### PR TITLE
Allow multiple managers

### DIFF
--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -56,7 +56,7 @@ import java.util.concurrent.TimeUnit;
  * Handles loading the Optimizely data file
  */
 public class OptimizelyManager {
-    @NonNull private static AndroidOptimizely androidOptimizely = new AndroidOptimizely(null,
+    @NonNull private AndroidOptimizely androidOptimizely = new AndroidOptimizely(null,
             LoggerFactory.getLogger(AndroidOptimizely.class));
     @NonNull private final String projectId;
     @NonNull private final Long eventHandlerDispatchInterval;
@@ -266,7 +266,7 @@ public class OptimizelyManager {
                 serviceScheduler.schedule(intent, dataFileDownloadIntervalTimeUnit.toMillis(dataFileDownloadInterval));
 
                 try {
-                    OptimizelyManager.androidOptimizely = buildOptimizely(context, dataFile, userExperimentRecord);
+                    OptimizelyManager.this.androidOptimizely = buildOptimizely(context, dataFile, userExperimentRecord);
                     OptimizelyManager.this.userExperimentRecord = userExperimentRecord;
                     logger.info("Sending Optimizely instance to listener");
 

--- a/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDAOTest.java
+++ b/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDAOTest.java
@@ -54,12 +54,12 @@ public class EventDAOTest {
     public void setupEventDAO() {
         logger = mock(Logger.class);
         context = InstrumentationRegistry.getTargetContext();
-        eventDAO = EventDAO.getInstance(context, logger);
+        eventDAO = EventDAO.getInstance(context, "1", logger);
     }
 
     @After
     public void tearDownEventDAO() {
-        context.deleteDatabase(EventSQLiteOpenHelper.DB_NAME);
+        assertTrue(context.deleteDatabase(String.format(EventSQLiteOpenHelper.DB_NAME , "1")));
     }
 
     @Test

--- a/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDispatcherTest.java
+++ b/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDispatcherTest.java
@@ -67,7 +67,7 @@ public class EventDispatcherTest {
         context = InstrumentationRegistry.getTargetContext();
         logger = mock(Logger.class);
         client = mock(Client.class);
-        eventDAO = EventDAO.getInstance(context, logger);
+        eventDAO = EventDAO.getInstance(context, "1", logger);
         eventClient = new EventClient(client, logger);
         serviceScheduler = mock(ServiceScheduler.class);
         optlyStorage = mock(OptlyStorage.class);
@@ -77,7 +77,7 @@ public class EventDispatcherTest {
 
     @After
     public void tearDown() {
-        context.deleteDatabase(EventSQLiteOpenHelper.DB_NAME);
+        context.deleteDatabase(String.format(EventSQLiteOpenHelper.DB_NAME, "1"));
     }
 
     @Test

--- a/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventSQLiteOpenHelperTest.java
+++ b/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventSQLiteOpenHelperTest.java
@@ -18,6 +18,8 @@ package com.optimizely.ab.android.event_handler;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -48,13 +50,14 @@ public class EventSQLiteOpenHelperTest {
 
     @After
     public void teardown() {
-        context.deleteDatabase(EventSQLiteOpenHelper.DB_NAME);
+        context.deleteDatabase(String.format(EventSQLiteOpenHelper.DB_NAME, "1"));
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void onCreateMakesTables() {
         EventSQLiteOpenHelper eventSQLiteOpenHelper =
-                new EventSQLiteOpenHelper(context, EventSQLiteOpenHelper.DB_NAME, null, 1, logger);
+                new EventSQLiteOpenHelper(context, "1", null, 1, logger);
         SQLiteDatabase db = eventSQLiteOpenHelper.getWritableDatabase();
         String[] projection = {
                 EventTable.Column._ID,

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventDAO.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventDAO.java
@@ -46,8 +46,8 @@ class EventDAO {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
-    static EventDAO getInstance(@NonNull Context context, @NonNull Logger logger) {
-        EventSQLiteOpenHelper sqLiteOpenHelper = new EventSQLiteOpenHelper(context, EventSQLiteOpenHelper.DB_NAME, null, EventSQLiteOpenHelper.VERSION, null, LoggerFactory.getLogger(EventSQLiteOpenHelper.class));
+    static EventDAO getInstance(@NonNull Context context, @NonNull String projectId, @NonNull Logger logger) {
+        EventSQLiteOpenHelper sqLiteOpenHelper = new EventSQLiteOpenHelper(context, projectId, null, EventSQLiteOpenHelper.VERSION, LoggerFactory.getLogger(EventSQLiteOpenHelper.class));
         return new EventDAO(sqLiteOpenHelper, logger);
     }
 

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventIntentService.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventIntentService.java
@@ -63,7 +63,7 @@ public class EventIntentService extends IntentService {
         OptlyStorage optlyStorage = new OptlyStorage(this);
         EventClient eventClient = new EventClient(new Client(optlyStorage,
                 LoggerFactory.getLogger(Client.class)), LoggerFactory.getLogger(EventClient.class));
-        EventDAO eventDAO = EventDAO.getInstance(this, LoggerFactory.getLogger(EventDAO.class));
+        EventDAO eventDAO = EventDAO.getInstance(this, "1", LoggerFactory.getLogger(EventDAO.class));
         ServiceScheduler serviceScheduler = new ServiceScheduler(
                 (AlarmManager) getSystemService(ALARM_SERVICE),
                 new ServiceScheduler.PendingIntentFactory(this),


### PR DESCRIPTION
These changes should enable multiple `OptimizelyManager` and `AndroidOptimizely` parings for each project.  Some users might find it convenient to be able to run multiple Optimizely projects inside of the same app.  For example, one project might test the copy of notifications shown from Android services and another project is used for `Activity` testing.

```
OptimizelyManager manager1 = OptimizelyManager.Builder("projectId1").build();
OptimizelyManager manager2 = OptimizelyManager.Builder("projectId2").build();
AndroidOptimizely optimizely1 = manager1.getOptimizely();
AndroidOptimizely optimizely2 = manager2.getOptimizely();
assert manager1 != manager2;
assert optimizely1 != optimizely2;
```

We were storing events for all projects in one table.  While, this would still work I think it's cleaner to have separate databases for each project.  Other parts of the SDK such as the User Experiment Record and the data file manager already account for multiple projects by appending the project ID to their file names.