### PR TITLE
Sets up exponential backoff for event dispatch and datafile download

### DIFF
--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/DataFileClientTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/DataFileClientTest.java
@@ -22,16 +22,20 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 
+import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.contains;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -63,12 +67,22 @@ public class DataFileClientTest {
         when(urlConnection.getResponseCode()).thenReturn(200);
         when(client.readStream(urlConnection)).thenReturn("{}");
 
-        String response = dataFileClient.request(url.toString());
-        assertEquals(response, "{}");
+        dataFileClient.request(url.toString());
+
+        ArgumentCaptor<Client.Request> captor1 = ArgumentCaptor.forClass(Client.Request.class);
+        ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> captor3 = ArgumentCaptor.forClass(Integer.class);
+        verify(client).execute(captor1.capture(), captor2.capture(), captor3.capture());
+        assertEquals(Integer.valueOf(2), captor2.getValue());
+        assertEquals(Integer.valueOf(3), captor3.getValue());
+        Object response = captor1.getValue().execute();
+        assertTrue(String.class.isInstance(response));
+        assertEquals("{}", response);
 
         verify(logger).info("Requesting data file from {}", url);
         verify(client).saveLastModified(urlConnection);
         verify(client).readStream(urlConnection);
+        verify(urlConnection).disconnect();
     }
 
     @Test
@@ -78,12 +92,22 @@ public class DataFileClientTest {
         when(urlConnection.getResponseCode()).thenReturn(201);
         when(client.readStream(urlConnection)).thenReturn("{}");
 
-        String response = dataFileClient.request(url.toString());
-        assertEquals(response, "{}");
+        dataFileClient.request(url.toString());
+
+        ArgumentCaptor<Client.Request> captor1 = ArgumentCaptor.forClass(Client.Request.class);
+        ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> captor3 = ArgumentCaptor.forClass(Integer.class);
+        verify(client).execute(captor1.capture(), captor2.capture(), captor3.capture());
+        assertEquals(Integer.valueOf(2), captor2.getValue());
+        assertEquals(Integer.valueOf(3), captor3.getValue());
+        Object response = captor1.getValue().execute();
+        assertTrue(String.class.isInstance(response));
+        assertEquals("{}", response);
 
         verify(logger).info("Requesting data file from {}", url);
         verify(client).saveLastModified(urlConnection);
         verify(client).readStream(urlConnection);
+        verify(urlConnection).disconnect();
     }
 
     @Test
@@ -93,12 +117,22 @@ public class DataFileClientTest {
         when(urlConnection.getResponseCode()).thenReturn(299);
         when(client.readStream(urlConnection)).thenReturn("{}");
 
-        String response = dataFileClient.request(url.toString());
-        assertEquals(response, "{}");
+        dataFileClient.request(url.toString());
+
+        ArgumentCaptor<Client.Request> captor1 = ArgumentCaptor.forClass(Client.Request.class);
+        ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> captor3 = ArgumentCaptor.forClass(Integer.class);
+        verify(client).execute(captor1.capture(), captor2.capture(), captor3.capture());
+        assertEquals(Integer.valueOf(2), captor2.getValue());
+        assertEquals(Integer.valueOf(3), captor3.getValue());
+        Object response = captor1.getValue().execute();
+        assertTrue(String.class.isInstance(response));
+        assertEquals("{}", response);
 
         verify(logger).info("Requesting data file from {}", url);
         verify(client).saveLastModified(urlConnection);
         verify(client).readStream(urlConnection);
+        verify(urlConnection).disconnect();
     }
 
     @Test
@@ -107,10 +141,18 @@ public class DataFileClientTest {
         when(client.openConnection(url)).thenReturn(urlConnection);
         when(urlConnection.getResponseCode()).thenReturn(300);
 
-        String response = dataFileClient.request(url.toString());
+        dataFileClient.request(url.toString());
+        ArgumentCaptor<Client.Request> captor1 = ArgumentCaptor.forClass(Client.Request.class);
+        ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> captor3 = ArgumentCaptor.forClass(Integer.class);
+        verify(client).execute(captor1.capture(), captor2.capture(), captor3.capture());
+        assertEquals(Integer.valueOf(2), captor2.getValue());
+        assertEquals(Integer.valueOf(3), captor3.getValue());
+        Object response = captor1.getValue().execute();
         assertNull(response);
 
         verify(logger).error("Unexpected response from data file cdn, status: {}", 300);
+        verify(urlConnection).disconnect();
     }
 
     @Test
@@ -120,10 +162,32 @@ public class DataFileClientTest {
         when(urlConnection.getResponseCode()).thenReturn(200);
         doThrow(new IOException()).when(client).readStream(urlConnection);
 
-        String response = dataFileClient.request(url.toString());
+        dataFileClient.request(url.toString());
+        ArgumentCaptor<Client.Request> captor1 = ArgumentCaptor.forClass(Client.Request.class);
+        ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> captor3 = ArgumentCaptor.forClass(Integer.class);
+        verify(client).execute(captor1.capture(), captor2.capture(), captor3.capture());
+        assertEquals(Integer.valueOf(2), captor2.getValue());
+        assertEquals(Integer.valueOf(3), captor3.getValue());
+        Object response = captor1.getValue().execute();
         assertNull(response);
 
         verify(logger).error(contains("Error making request"), any(IOException.class));
         verify(urlConnection).disconnect();
+        verify(urlConnection).disconnect();
+    }
+
+    @Test
+    public void handlesNullResponse() throws MalformedURLException {
+        URL url = new URL(String.format(DataFileLoader.RequestDataFileFromClientTask.FORMAT_CDN_URL, "1"));
+        when(client.execute(any(Client.Request.class), eq(2), eq(3))).thenReturn(null);
+        assertNull(dataFileClient.request(url.toString()));
+    }
+
+    @Test
+    public void handlesEmptyStringResponse() throws MalformedURLException {
+        URL url = new URL(String.format(DataFileLoader.RequestDataFileFromClientTask.FORMAT_CDN_URL, "1"));
+        when(client.execute(any(Client.Request.class), eq(2), eq(3))).thenReturn("");
+        assertNull(dataFileClient.request(url.toString()));
     }
 }

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/DataFileClient.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/DataFileClient.java
@@ -39,38 +39,50 @@ class DataFileClient {
         this.logger = logger;
     }
 
-    String request(String urlString) {
-        HttpURLConnection urlConnection = null;
-        try {
-            URL url = new URL(urlString);
-            logger.info("Requesting data file from {}", url);
-            urlConnection = client.openConnection(url);
+    String request(final String urlString) {
+        Client.Request<String> request = new Client.Request<String>() {
+            @Override
+            public String execute() {
+                HttpURLConnection urlConnection = null;
+                try {
+                    URL url = new URL(urlString);
+                    logger.info("Requesting data file from {}", url);
+                    urlConnection = client.openConnection(url);
 
-            client.setIfModifiedSince(urlConnection);
+                    client.setIfModifiedSince(urlConnection);
 
-            urlConnection.setConnectTimeout(5 * 1000);
-            urlConnection.connect();
+                    urlConnection.setConnectTimeout(5 * 1000);
+                    urlConnection.connect();
 
-            int status = urlConnection.getResponseCode();
-            if (status >= 200 && status < 300) {
-                client.saveLastModified(urlConnection);
-                return client.readStream(urlConnection);
-            } else if (status == 304) {
-                logger.info("Data file has not been modified on the cdn");
-                return null;
-            } else {
-                logger.error("Unexpected response from data file cdn, status: {}", status);
-                return null;
+                    int status = urlConnection.getResponseCode();
+                    if (status >= 200 && status < 300) {
+                        client.saveLastModified(urlConnection);
+                        return client.readStream(urlConnection);
+                    } else if (status == 304) {
+                        logger.info("Data file has not been modified on the cdn");
+                        return "";
+                    } else {
+                        logger.error("Unexpected response from data file cdn, status: {}", status);
+                        return null;
+                    }
+                } catch (IOException e) {
+                    logger.error("Error making request", e);
+                    return null;
+                } finally {
+                    if (urlConnection != null) {
+                        urlConnection.disconnect();
+                    }
+                }
             }
-        } catch (IOException e) {
-            logger.error("Error making request", e);
-            return null;
-        } finally {
-            if (urlConnection != null) {
-                urlConnection.disconnect();
-            }
+        };
+
+        // If the response was a 304 Not Modified an empty string is returned
+        // Consumers of this method expect either a valid datafile or null
+        String response = client.execute(request, 2, 3);
+        if (response != null && response.isEmpty()) {
+            response = null;
         }
+
+        return response;
     }
-
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -83,4 +83,4 @@ task testAllModules << {
 
 testAllModules.dependsOn(':android-sdk:connectedAndroidTest', ':android-sdk:test',
         ':event-handler:connectedAndroidTest', ':event-handler:test',
-        ':user-experiment-record:connectedAndroidTest', ':shared:connectedAndroidTest')
+        ':user-experiment-record:connectedAndroidTest', ':shared:connectedAndroidTest', ':test-app:connectedAndroidTest')

--- a/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDispatcherTest.java
+++ b/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDispatcherTest.java
@@ -42,6 +42,7 @@ import java.net.URL;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.contains;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -103,7 +104,6 @@ public class EventDispatcherTest {
         verify(serviceScheduler).schedule(mockIntent, AlarmManager.INTERVAL_HOUR);
         verify(optlyStorage).saveLong(EventIntentService.EXTRA_INTERVAL, AlarmManager.INTERVAL_HOUR);
 
-        verify(logger).error("Unexpected response from event endpoint, status: " + 400);
         verify(logger).info("Scheduled events to be dispatched");
     }
 

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventClientTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventClientTest.java
@@ -20,6 +20,7 @@ import com.optimizely.ab.android.shared.Client;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
@@ -28,10 +29,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,7 +72,16 @@ public class EventClientTest {
         InputStream inputStream = mock(InputStream.class);
         when(urlConnection.getInputStream()).thenReturn(inputStream);
 
-        assertTrue(eventClient.sendEvent(event));
+        eventClient.sendEvent(event);
+        ArgumentCaptor<Client.Request> captor1 = ArgumentCaptor.forClass(Client.Request.class);
+        ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> captor3 = ArgumentCaptor.forClass(Integer.class);
+        verify(client).execute(captor1.capture(), captor2.capture(), captor3.capture());
+        assertEquals(Integer.valueOf(2), captor2.getValue());
+        assertEquals(Integer.valueOf(5), captor3.getValue());
+        Object response = captor1.getValue().execute();
+        assertEquals(Boolean.TRUE, response);
+
         verify(logger).info("Dispatching event: {}", event);
     }
 
@@ -78,7 +92,16 @@ public class EventClientTest {
         InputStream inputStream = mock(InputStream.class);
         when(urlConnection.getInputStream()).thenReturn(inputStream);
 
-        assertTrue(eventClient.sendEvent(event));
+        eventClient.sendEvent(event);
+        ArgumentCaptor<Client.Request> captor1 = ArgumentCaptor.forClass(Client.Request.class);
+        ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> captor3 = ArgumentCaptor.forClass(Integer.class);
+        verify(client).execute(captor1.capture(), captor2.capture(), captor3.capture());
+        assertEquals(Integer.valueOf(2), captor2.getValue());
+        assertEquals(Integer.valueOf(5), captor3.getValue());
+        Object response = captor1.getValue().execute();
+        assertEquals(Boolean.TRUE, response);
+
         verify(logger).info("Dispatching event: {}", event);
     }
 
@@ -89,7 +112,16 @@ public class EventClientTest {
         InputStream inputStream = mock(InputStream.class);
         when(urlConnection.getInputStream()).thenReturn(inputStream);
 
-        assertFalse(eventClient.sendEvent(event));
+        eventClient.sendEvent(event);
+        ArgumentCaptor<Client.Request> captor1 = ArgumentCaptor.forClass(Client.Request.class);
+        ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> captor3 = ArgumentCaptor.forClass(Integer.class);
+        verify(client).execute(captor1.capture(), captor2.capture(), captor3.capture());
+        assertEquals(Integer.valueOf(2), captor2.getValue());
+        assertEquals(Integer.valueOf(5), captor3.getValue());
+        Object response = captor1.getValue().execute();
+        assertEquals(Boolean.FALSE, response);
+
         verify(logger).info("Dispatching event: {}", event);
         verify(logger).error("Unexpected response from event endpoint, status: 300");
     }
@@ -101,7 +133,15 @@ public class EventClientTest {
         when(urlConnection.getResponseCode()).thenReturn(200);
         when(urlConnection.getInputStream()).thenThrow(IOException.class);
 
-        assertFalse(eventClient.sendEvent(event));
+        eventClient.sendEvent(event);
+        ArgumentCaptor<Client.Request> captor1 = ArgumentCaptor.forClass(Client.Request.class);
+        ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> captor3 = ArgumentCaptor.forClass(Integer.class);
+        verify(client).execute(captor1.capture(), captor2.capture(), captor3.capture());
+        assertEquals(Integer.valueOf(2), captor2.getValue());
+        assertEquals(Integer.valueOf(5), captor3.getValue());
+        Object response = captor1.getValue().execute();
+        assertEquals(Boolean.FALSE, response);
         verify(logger).info("Dispatching event: {}", event);
 
     }
@@ -111,8 +151,22 @@ public class EventClientTest {
     public void sendEventsIoExceptionOpenConnection() throws IOException {
         when(client.openConnection(event.getURL())).thenThrow(IOException.class);
 
-        assertFalse(eventClient.sendEvent(event));
+        eventClient.sendEvent(event);
+        ArgumentCaptor<Client.Request> captor1 = ArgumentCaptor.forClass(Client.Request.class);
+        ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> captor3 = ArgumentCaptor.forClass(Integer.class);
+        verify(client).execute(captor1.capture(), captor2.capture(), captor3.capture());
+        assertEquals(Integer.valueOf(2), captor2.getValue());
+        assertEquals(Integer.valueOf(5), captor3.getValue());
+        Object response = captor1.getValue().execute();
+        assertEquals(Boolean.FALSE, response);
         verify(logger).info("Dispatching event: {}", event);
+    }
 
+    @Test
+    public void convertsNullResponseToFalse() {
+        Event event = mock(Event.class);
+        when(client.execute(any(Client.Request.class), eq(2), eq(5))).thenReturn(null);
+        assertFalse(eventClient.sendEvent(event));
     }
 }

--- a/shared/src/main/java/com/optimizely/ab/android/shared/Client.java
+++ b/shared/src/main/java/com/optimizely/ab/android/shared/Client.java
@@ -27,6 +27,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Scanner;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Functionality common to all clients
@@ -115,7 +116,7 @@ public class Client {
             if (response == null || response == Boolean.FALSE) {
                 try {
                     logger.info("Request failed, waiting {} seconds to try again", timeout);
-                    Thread.sleep(timeout);
+                    Thread.sleep(TimeUnit.MILLISECONDS.convert(timeout, TimeUnit.SECONDS));
                 } catch (InterruptedException e) {
                     logger.warn("Exponential backoff failed", e);
                     break;

--- a/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.java
+++ b/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.java
@@ -66,7 +66,7 @@ public class MyApplication extends Application {
         // must match the project id of the compiled in Optimizely data file in rest/raw/data_file.json.
         optimizelyManager = OptimizelyManager.builder(PROJECT_ID)
                 .withEventHandlerDispatchInterval(3, TimeUnit.SECONDS)
-                .withDataFileDownloadInterval(30, TimeUnit.MINUTES)
+                .withDataFileDownloadInterval(30, TimeUnit.SECONDS)
                 .build();
     }
 }


### PR DESCRIPTION
Datafile download and event dispatch were both happening synchronously on background threads.  We simply need to make the client's request method handle exponential backoff internally.  As much as possible was moved into the shared library since the event client and datafile client both use the same client core.

Tested e2e manually via logs and putting a phone into airplane mode.  There is no easy way to programmatically cause network failures.  Added more unit test coverage.  