### PR TITLE
Allows service intervals to be changed after they are scheduled

### DIFF
--- a/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/ServiceSchedulerTest.java
+++ b/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/ServiceSchedulerTest.java
@@ -103,10 +103,11 @@ public class ServiceSchedulerTest {
     public void testAlreadyScheduledAlarm() {
         final Intent intent = new Intent(context, EventIntentService.class);
         when(pendingIntentFactory.hasPendingIntent(intent)).thenReturn(true);
+        when(pendingIntentFactory.getPendingIntent(intent)).thenReturn(PendingIntent.getService(InstrumentationRegistry.getTargetContext(), 1, intent, 0));
 
         serviceScheduler.schedule(intent, AlarmManager.INTERVAL_HOUR);
 
-        verify(logger).debug("Not scheduling {}. It's already scheduled", intent.getComponent().toShortString());
+        verify(logger).info("Unscheduled {}", intent.getComponent().toShortString());
     }
 
     @Test

--- a/shared/src/main/java/com/optimizely/ab/android/shared/ServiceScheduler.java
+++ b/shared/src/main/java/com/optimizely/ab/android/shared/ServiceScheduler.java
@@ -50,6 +50,9 @@ public class ServiceScheduler {
     /**
      * Schedule a service starting {@link Intent} that starts on an interval
      *
+     * Previously scheduled services matching this intent will be unscheduled.  They will
+     * match even if the interval is different.
+     *
      * @param intent   an {@link Intent}
      * @param interval the interval in MS
      * @hide
@@ -60,15 +63,14 @@ public class ServiceScheduler {
             return;
         }
 
-        if (!pendingIntentFactory.hasPendingIntent(intent)) {
-
-            PendingIntent pendingIntent = pendingIntentFactory.getPendingIntent(intent);
-            alarmManager.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, interval, interval, pendingIntent);
-
-            logger.info("Scheduled {}", intent.getComponent().toShortString());
-        } else {
-            logger.debug("Not scheduling {}. It's already scheduled", intent.getComponent().toShortString());
+        if (isScheduled(intent)) {
+            unschedule(intent);
         }
+
+        PendingIntent pendingIntent = pendingIntentFactory.getPendingIntent(intent);
+        alarmManager.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, interval, interval, pendingIntent);
+
+        logger.info("Scheduled {}", intent.getComponent().toShortString());
     }
 
     /**


### PR DESCRIPTION
We had a small bug that prevented the interval of services from being changed once they are scheduled the first time.