### PR TITLE
Preemptively flush events when wifi is available if available

### DIFF
--- a/.idea/dictionaries/jdeffibaugh.xml
+++ b/.idea/dictionaries/jdeffibaugh.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="jdeffibaugh">
+    <words>
+      <w>preemptively</w>
+    </words>
+  </dictionary>
+</component>

--- a/event-handler/src/main/AndroidManifest.xml
+++ b/event-handler/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.net.wifi.supplicant.CONNECTION_CHANGE" />
             </intent-filter>
         </receiver>
     </application>

--- a/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.java
+++ b/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.java
@@ -65,8 +65,8 @@ public class MyApplication extends Application {
         // tests setup not work and the Espresso tests will fail.  Also, the project id passed here
         // must match the project id of the compiled in Optimizely data file in rest/raw/data_file.json.
         optimizelyManager = OptimizelyManager.builder(PROJECT_ID)
-                .withEventHandlerDispatchInterval(3, TimeUnit.SECONDS)
-                .withDataFileDownloadInterval(30, TimeUnit.SECONDS)
+                .withEventHandlerDispatchInterval(3, TimeUnit.MINUTES)
+                .withDataFileDownloadInterval(30, TimeUnit.MINUTES)
                 .build();
     }
 }


### PR DESCRIPTION
Only will happen if an event flush is scheduled.