### PR TITLE
Remove optly repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url  "http://optimizely.bintray.com/optimizely"
-        }
     }
 }
 

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -26,21 +26,18 @@ android {
     }
 }
 
-repositories {
-    maven { url 'http://dl.bintray.com/optimizely/optimizely' }
-}
-
 dependencies {
     // Includes SST Java core, event handler, and user experiment record
-    compile project(':android-sdk')
-//    compile 'com.optimizely.ab:android-sdk:0.1.2-SNAPSHOT'
+//    compile project(':android-sdk')
+    compile 'com.optimizely.ab:android-sdk:0.2.0'
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 
     testCompile "junit:junit:$junit_ver"
     testCompile "org.mockito:mockito-core:$mockito_ver"
     testCompile "com.noveogroup.android:android-logger:$android_logger_ver"
-    testCompile project(':android-sdk')
+    testCompile 'com.optimizely.ab:android-sdk:0.2.0'
+//    testCompile project(':android-sdk')
 
     androidTestCompile("com.android.support.test:runner:$support_test_runner_ver")
     androidTestCompile "com.android.support:support-annotations:24.2.1"
@@ -51,5 +48,6 @@ dependencies {
     androidTestCompile "org.mockito:mockito-core:$mockito_ver"
     androidTestCompile "com.google.dexmaker:dexmaker:$dexmaker_ver"
     androidTestCompile "com.google.dexmaker:dexmaker-mockito:$dexmaker_ver"
-    androidTestCompile project(':android-sdk')
+    androidTestCompile 'com.optimizely.ab:android-sdk:0.2.0'
+//    androidTestCompile project(':android-sdk')
 }

--- a/test-app/src/main/res/layout/activity_main.xml
+++ b/test-app/src/main/res/layout/activity_main.xml
@@ -10,12 +10,14 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context=".MainActivity">
 
-    <Button
-        android:id="@+id/button_1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:text="@string/main_act_button_1_text_default"/>
+        <Button
+            android:id="@+id/button_1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:text="@string/main_act_button_1_text_default"/>
+
+
 
     <TextView
         android:id="@+id/text_view_1"


### PR DESCRIPTION
We are open source so our repo can be mirrored in jcenter and maven central.  Users no longer need to declare our repo.