### PR TITLE
Nulls out the dataFileService connection

### DIFF
--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/DataFileReschedulerTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/DataFileReschedulerTest.java
@@ -24,6 +24,7 @@ import android.support.test.InstrumentationRegistry;
 import com.optimizely.ab.android.shared.Cache;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -86,6 +87,7 @@ public class DataFileReschedulerTest {
 
     @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
     @Test
+    @Ignore
     public void dispatchingOne() {
         Context mockContext = mock(Context.class);
         Cache cache = new Cache(InstrumentationRegistry.getTargetContext(), logger);

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/DataFileReschedulerTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/DataFileReschedulerTest.java
@@ -87,7 +87,6 @@ public class DataFileReschedulerTest {
 
     @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
     @Test
-    @Ignore
     public void dispatchingOne() {
         Context mockContext = mock(Context.class);
         Cache cache = new Cache(InstrumentationRegistry.getTargetContext(), logger);

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerTest.java
@@ -107,7 +107,7 @@ public class OptimizelyManagerTest {
         Context appContext = mock(Context.class);
         when(context.getApplicationContext()).thenReturn(appContext);
 
-        OptimizelyManager.DataFileServiceConnection dataFileServiceConnection = new OptimizelyManager.DataFileServiceConnection(optimizelyManager);
+        OptimizelyManager.DataFileServiceConnection dataFileServiceConnection = new OptimizelyManager.DataFileServiceConnection(optimizelyManager, context);
         dataFileServiceConnection.setBound(true);
         optimizelyManager.setDataFileServiceConnection(dataFileServiceConnection);
 

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -265,6 +265,7 @@ public class OptimizelyManager {
         }
         if (dataFileServiceConnection != null && dataFileServiceConnection.isBound()) {
             context.getApplicationContext().unbindService(dataFileServiceConnection);
+            dataFileServiceConnection = null;
         }
 
         this.optimizelyStartListener = null;
@@ -522,6 +523,7 @@ public class OptimizelyManager {
         @Override
         public void onServiceDisconnected(ComponentName arg0) {
             bound = false;
+            optimizelyManager.setDataFileServiceConnection(null);
         }
 
         boolean isBound() {

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -149,7 +149,7 @@ public class OptimizelyManager {
         // the user can instantiate with the latest datafile
         final Intent intent = new Intent(context.getApplicationContext(), DataFileService.class);
         if (dataFileServiceConnection == null) {
-            this.dataFileServiceConnection = new DataFileServiceConnection(this);
+            this.dataFileServiceConnection = new DataFileServiceConnection(this, context);
             context.getApplicationContext().bindService(intent, dataFileServiceConnection, Context.BIND_AUTO_CREATE);
         }
 
@@ -239,7 +239,7 @@ public class OptimizelyManager {
         this.optimizelyStartListener = optimizelyStartListener;
         final Intent intent = new Intent(context.getApplicationContext(), DataFileService.class);
         if (dataFileServiceConnection == null) {
-            this.dataFileServiceConnection = new DataFileServiceConnection(this);
+            this.dataFileServiceConnection = new DataFileServiceConnection(this, context);
             context.getApplicationContext().bindService(intent, dataFileServiceConnection, Context.BIND_AUTO_CREATE);
         }
     }
@@ -457,10 +457,12 @@ public class OptimizelyManager {
     static class DataFileServiceConnection implements ServiceConnection {
 
         @NonNull private final OptimizelyManager optimizelyManager;
+        @NonNull private final Context context;
         private boolean bound = false;
 
-        DataFileServiceConnection(@NonNull OptimizelyManager optimizelyManager) {
+        DataFileServiceConnection(@NonNull OptimizelyManager optimizelyManager, @NonNull Context context) {
             this.optimizelyManager = optimizelyManager;
+            this.context = context;
         }
 
         /**
@@ -523,7 +525,7 @@ public class OptimizelyManager {
         @Override
         public void onServiceDisconnected(ComponentName arg0) {
             bound = false;
-            optimizelyManager.setDataFileServiceConnection(null);
+            optimizelyManager.stop(context);
         }
 
         boolean isBound() {

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerDataFileServiceConnectionTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerDataFileServiceConnectionTest.java
@@ -49,7 +49,7 @@ public class OptimizelyManagerDataFileServiceConnectionTest {
 
     @Before
     public void setup() {
-        dataFileServiceConnection = new OptimizelyManager.DataFileServiceConnection(optimizelyManager);
+        dataFileServiceConnection = new OptimizelyManager.DataFileServiceConnection(optimizelyManager, mock(Context.class));
     }
 
     @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)


### PR DESCRIPTION
Since we are using the nullability of the dataFileServiceConnection to control whether we can bind we need to null it out so that subsequent start and initialize calls still try to bind the service.  

Generally, most apps will probably have one OptimizelyManager instance.  Without this change you couldn't call initialize on more than one activity.