### PR TITLE
Make getDatafileUrl static for easier access.

### DIFF
--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -324,7 +324,7 @@ public class OptimizelyManager {
      * Returns the URL of the versioned datafile that this SDK expects to use
      * @return the CDN location of the datafile
      */
-    public @NonNull String getDatafileUrl() {
+    public static @NonNull String getDatafileUrl(String projectId) {
         return DataFileService.getDatafileUrl(projectId);
     }
 

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -322,6 +322,7 @@ public class OptimizelyManager {
 
     /**
      * Returns the URL of the versioned datafile that this SDK expects to use
+     * @param projectId The id of the project for which we are getting the datafile
      * @return the CDN location of the datafile
      */
     public static @NonNull String getDatafileUrl(String projectId) {


### PR DESCRIPTION
@optimizely/fullstack-devs 

It makes more sense to have this method be static as it'll be easier for the developer to use instead of having to rely on an instance. Also matches what iOS has, which is a static class method. 