### PR TITLE
Update proguard-rules.pro

### DIFF
--- a/shared/proguard-rules.pro
+++ b/shared/proguard-rules.pro
@@ -15,3 +15,8 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-keepnames class com.google.gson.Gson
+-keepnames class com.fasterxml.jackson.databind.ObjectMappe
+-keepnames class org.json.simple.JSONObject
+-keepnames class org.json.JSONObject


### PR DESCRIPTION
The java core needs this class names to be intact to detect the right parser to use.  The Android SDK compiles gson so it should be available.  Ebay's proguard issue indicated that org.json.JSONObject was being used, however.  The reason gson is compiled is because Android's JSONObject and the JDKs are different and incompatible.  It's difficult to override Android's because it's part of the library.