### PR TITLE
Very rough batch implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -42,6 +42,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()
         jcenter()
     }
 }
@@ -52,7 +53,7 @@ ext {
     min_sdk_version = 10
     target_sdk_version = 24
 
-    java_core_ver = "1.6.0"
+    java_core_ver = "1.6.0-SNAPSHOT"
     android_logger_ver = "1.3.1"
     support_annotations_ver = "24.2.1"
     junit_ver = "4.12"

--- a/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDispatcherTest.java
+++ b/event-handler/src/androidTest/java/com/optimizely/ab/android/event_handler/EventDispatcherTest.java
@@ -16,17 +16,18 @@
 
 package com.optimizely.ab.android.event_handler;
 
-import android.app.AlarmManager;
 import android.content.Context;
-import android.content.Intent;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.google.gson.Gson;
 import com.optimizely.ab.android.shared.Client;
 import com.optimizely.ab.android.shared.OptlyStorage;
 import com.optimizely.ab.android.shared.ServiceScheduler;
+import com.optimizely.ab.event.internal.payload.batch.*;
+import com.optimizely.ab.event.internal.payload.batch.Event;
 
 import org.junit.After;
 import org.junit.Before;
@@ -40,11 +41,14 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.contains;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -61,6 +65,7 @@ public class EventDispatcherTest {
     private Logger logger;
     private Context context;
     private Client client;
+    private Gson gson;
 
     @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
     @Before
@@ -72,8 +77,10 @@ public class EventDispatcherTest {
         eventClient = new EventClient(client, logger);
         serviceScheduler = mock(ServiceScheduler.class);
         optlyStorage = mock(OptlyStorage.class);
+        gson = new Gson();
 
-        eventDispatcher = new EventDispatcher(context, optlyStorage, eventDAO, eventClient, serviceScheduler, logger);
+        eventDispatcher = new EventDispatcher(context, optlyStorage, eventDAO, eventClient,
+                serviceScheduler, gson, logger);
     }
 
     @After
@@ -82,70 +89,60 @@ public class EventDispatcherTest {
     }
 
     @Test
-    public void handleIntentSchedulesWhenEventsLeftInStorage() throws IOException {
-        Event event1 = new Event(new URL("http://www.foo1.com"), "");
-        Event event2 = new Event(new URL("http://www.foo2.com"), "");
-        Event event3= new Event(new URL("http://www.foo3.com"), "");
-        eventDAO.storeEvent(event1);
-        eventDAO.storeEvent(event2);
-        eventDAO.storeEvent(event3);
+    public void merge() throws MalformedURLException {
+        Batch batch1 = new Batch("1");
+        Batch batch2 = new Batch("1");
 
-        final HttpURLConnection goodConnection = getGoodConnection();
-        when(client.openConnection(event1.getURL())).thenReturn(goodConnection);
-        when(client.openConnection(event2.getURL())).thenReturn(goodConnection);
-        final HttpURLConnection badConnection = getBadConnection();
-        when(client.openConnection(event3.getURL())).thenReturn(badConnection);
+        Visitor visitor1 = new Visitor("1");
+        Visitor visitor2 = new Visitor("1");
+        List<Visitor> visitors1 = Arrays.asList(visitor1);
+        List<Visitor> visitors2 = Arrays.asList(visitor2);
 
-        Intent mockIntent = mock(Intent.class);
-        when(mockIntent.getLongExtra(EventIntentService.EXTRA_INTERVAL, -1)).thenReturn(-1L);
-        when(optlyStorage.getLong(EventIntentService.EXTRA_INTERVAL, AlarmManager.INTERVAL_HOUR)).thenReturn(AlarmManager.INTERVAL_HOUR);
-        eventDispatcher.dispatch(mockIntent);
+        Decision decision1 = new Decision("1", "1", false, "1");
+        Decision decision2 = new Decision("2", "2", false, "2");
+        List<Decision> decisionList = Arrays.asList(decision1, decision2);
 
-        verify(serviceScheduler).schedule(mockIntent, AlarmManager.INTERVAL_HOUR);
-        verify(optlyStorage).saveLong(EventIntentService.EXTRA_INTERVAL, AlarmManager.INTERVAL_HOUR);
+        com.optimizely.ab.event.internal.payload.batch.Event event1 = new Event("campaign_activated", System.currentTimeMillis(), UUID.randomUUID().toString());
+        com.optimizely.ab.event.internal.payload.batch.Event event2 = new Event("campaign_activated", System.currentTimeMillis(), UUID.randomUUID().toString());
+        List<com.optimizely.ab.event.internal.payload.batch.Event> events1 = Arrays.asList(event1);
+        List<com.optimizely.ab.event.internal.payload.batch.Event> events2 = Arrays.asList(event2);
 
-        verify(logger).info("Scheduled events to be dispatched");
+        Snapshot snapshot1 = new Snapshot(decisionList, events1);
+        Snapshot snapshot2 = new Snapshot(decisionList, events2);
+        List<Snapshot> snapshots1 = Arrays.asList(snapshot1);
+        List<Snapshot> snapshots2 = Arrays.asList(snapshot2);
+
+        visitor1.setSnapshots(snapshots1);
+        visitor2.setSnapshots(snapshots2);
+
+        batch1.setVisitors(visitors1);
+        batch2.setVisitors(visitors2);
+
+        Gson gson = new Gson();
+        com.optimizely.ab.android.event_handler.Event eventReq1 = new com.optimizely.ab.android.event_handler.Event(new URL("http://www.optimizely.com"), gson.toJson(batch1, Batch.class));
+        com.optimizely.ab.android.event_handler.Event eventReq2 = new com.optimizely.ab.android.event_handler.Event(new URL("http://www.optimizely.com"), gson.toJson(batch2, Batch.class));
+
+        com.optimizely.ab.android.event_handler.Event mergedEventReq = eventDispatcher.mergeBatches(Arrays.asList(eventReq1, eventReq2));
+
+        assertEquals(new URL("http://www.optimizely.com"), mergedEventReq.getURL());
+
+        Batch mergedBatch = gson.fromJson(mergedEventReq.getRequestBody(), Batch.class);
+        assertEquals("1", mergedBatch.getAccountId());
+        assertEquals(1, mergedBatch.getVisitors().size());
+        Visitor mergedVisitor = mergedBatch.getVisitors().get(0);
+        assertEquals("1", mergedVisitor.getVisitorId());
+        assertEquals(1, mergedVisitor.getSnapshots().size());
+        Snapshot snapshot = mergedVisitor.getSnapshots().get(0);
+        assertEquals(2, snapshot.getDecisions().size());
+        List<Decision> decisions = snapshot.getDecisions();
+        assertTrue(decisions.contains(decision1));
+        assertTrue(decisions.contains(decision2));
+        assertEquals(2, snapshot.getEvents().size());
+        List<Event> events = snapshot.getEvents();
+        assertTrue(events.contains(event1));
+        assertTrue(events.contains(event2));
     }
 
-    @Test
-    public void handleIntentSchedulesWhenNewEventFailsToSend() throws IOException {
-        Event event = new Event(new URL("http://www.foo.com"), "");
-
-        Intent intent = new Intent(context, EventIntentService.class);
-        intent.putExtra(EventIntentService.EXTRA_INTERVAL, AlarmManager.INTERVAL_HOUR);
-        intent.putExtra(EventIntentService.EXTRA_URL, event.getURL().toString());
-        intent.putExtra(EventIntentService.EXTRA_REQUEST_BODY, event.getRequestBody());
-
-        final HttpURLConnection badConnection = getBadConnection();
-        when(client.openConnection(event.getURL())).thenReturn(badConnection);
-
-        eventDispatcher.dispatch(intent);
-        verify(serviceScheduler).schedule(intent, AlarmManager.INTERVAL_HOUR);
-        verify(optlyStorage).saveLong(EventIntentService.EXTRA_INTERVAL, AlarmManager.INTERVAL_HOUR);
-
-        verify(logger).info("Scheduled events to be dispatched");
-    }
-
-    @Test
-    public void unschedulesServiceWhenNoEventsToFlush() {
-        Intent mockIntent = mock(Intent.class);
-        eventDispatcher.dispatch(mockIntent);
-        verify(serviceScheduler).unschedule(mockIntent);
-        verify(logger).info("Unscheduled event dispatch");
-    }
-
-    @Test
-    public void handleMalformedURL() throws MalformedURLException {
-        String url= "foo";
-
-        Intent mockIntent = mock(Intent.class);
-        when(mockIntent.hasExtra(EventIntentService.EXTRA_URL)).thenReturn(true);
-        when(mockIntent.getStringExtra(EventIntentService.EXTRA_URL)).thenReturn(url);
-
-        eventDispatcher.dispatch(mockIntent);
-
-        verify(logger).error(contains("Received a malformed URL in event handler service"), any(MalformedURLException.class));
-    }
 
     private HttpURLConnection getGoodConnection() throws IOException {
         HttpURLConnection httpURLConnection = getConnection();

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventDispatcher.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventDispatcher.java
@@ -22,16 +22,28 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.util.Pair;
 
+import com.google.gson.Gson;
 import com.optimizely.ab.android.shared.CountingIdlingResourceManager;
 import com.optimizely.ab.android.shared.OptlyStorage;
 import com.optimizely.ab.android.shared.ServiceScheduler;
+import com.optimizely.ab.event.internal.payload.batch.Attribute;
+import com.optimizely.ab.event.internal.payload.batch.Batch;
+import com.optimizely.ab.event.internal.payload.batch.Decision;
+import com.optimizely.ab.event.internal.payload.batch.Snapshot;
+import com.optimizely.ab.event.internal.payload.batch.Visitor;
 
 import org.slf4j.Logger;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Dispatches {@link Event} instances sent to {@link EventIntentService}
@@ -48,51 +60,45 @@ class EventDispatcher {
     @NonNull private final EventClient eventClient;
     @NonNull private final Logger logger;
     @NonNull private final OptlyStorage optlyStorage;
+    @NonNull private final Gson gson;
 
-    EventDispatcher(@NonNull Context context, @NonNull OptlyStorage optlyStorage, @NonNull EventDAO eventDAO, @NonNull EventClient eventClient, @NonNull ServiceScheduler serviceScheduler, @NonNull Logger logger) {
+    EventDispatcher(@NonNull Context context, @NonNull OptlyStorage optlyStorage,
+                    @NonNull EventDAO eventDAO, @NonNull EventClient eventClient,
+                    @NonNull ServiceScheduler serviceScheduler, @NonNull Gson gson, @NonNull Logger logger) {
         this.context = context;
         this.optlyStorage = optlyStorage;
         this.eventDAO = eventDAO;
         this.eventClient = eventClient;
         this.serviceScheduler = serviceScheduler;
+        this.gson = gson;
         this.logger = logger;
     }
 
-    void dispatch(@NonNull Intent intent) {
-        // Dispatch events still in storage
-        boolean dispatched = dispatch();
-
+    void store(@NonNull Intent intent) {
         if (intent.hasExtra(EventIntentService.EXTRA_URL)) {
             try {
                 String urlExtra = intent.getStringExtra(EventIntentService.EXTRA_URL);
                 String requestBody = intent.getStringExtra(EventIntentService.EXTRA_REQUEST_BODY);
                 Event event = new Event(new URL(urlExtra), requestBody);
-                // Send the event that triggered this run of the service for store it if sending fails
-                dispatched = dispatch(event);
-            } catch (MalformedURLException e) {
-                logger.error("Received a malformed URL in event handler service", e);
+                // Store this event for merging and sending in a batch later
+                store(event);
             } catch (Exception e) {
-                logger.warn("Failed to dispatch event.", e);
+                logger.warn("Failed to store event.", e);
             }
-        }
-
-
-        try {
-            if (!dispatched) {
-                long interval = getInterval(intent);
-                serviceScheduler.schedule(intent, interval);
-                saveInterval(interval);
-                logger.info("Scheduled events to be dispatched");
-            } else {
-                // Quit trying to dispatch events because their aren't any in storage
-                serviceScheduler.unschedule(intent);
-                logger.info("Unscheduled event dispatch");
-            }
-        } catch (Exception e) {
-            logger.warn("Failed to schedule event dispatch.", e);
         }
 
         eventDAO.closeDb();
+    }
+
+    void schedule(@NonNull Intent intent) {
+        try {
+            long interval = getInterval(intent);
+            serviceScheduler.schedule(intent, interval);
+            saveInterval(interval);
+            logger.info("Scheduled events to be dispatched");
+        } catch (Exception e) {
+            logger.warn("Failed to schedule event dispatch.", e);
+        }
     }
 
     // Either grab the interval for the first time from Intent or from storage
@@ -112,50 +118,85 @@ class EventDispatcher {
     }
 
     /**
-     * Dispatch all events in storage
-     *
-     * @return true if all events were dispatched, otherwise false
+     * Flush all events in storage
      */
-    private boolean dispatch() {
+    void flush() {
         List<Pair<Long, Event>> events = eventDAO.getEvents();
-        Iterator<Pair<Long,Event>> iterator = events.iterator();
-        while (iterator.hasNext()) {
-            Pair<Long, Event> event = iterator.next();
-            boolean eventWasSent = eventClient.sendEvent(event.second);
-            if (eventWasSent) {
-                iterator.remove();
-                boolean eventWasDeleted = eventDAO.removeEvent(event.first);
-                if (!eventWasDeleted) {
-                    logger.warn("Unable to delete an event from local storage that was sent to successfully");
+
+        for (List<Event> batches: partitionEventsByProject(events).values()) {
+            Event mergedBatch = mergeBatches(batches);
+            // send the merged batch
+            boolean wasSent = eventClient.sendEvent(mergedBatch);
+            if (wasSent) {
+                for (Pair<Long, Event> event : events) {
+                    // Remove everything if batch was successful
+                    boolean wasDeleted = eventDAO.removeEvent(event.first);
+                    if (!wasDeleted) {
+                        logger.warn("Unable to delete an event from local storage that was sent to successfully");
+                    }
+                }
+            }
+        }
+    }
+
+    private Map<String, List<Event>> partitionEventsByProject(List<Pair<Long, Event>> events) {
+        Map<String, List<Event>> projectIdToBatches = new HashMap<>();
+        for (Pair<Long, Event> event : events) {
+            Batch b = gson.fromJson(event.second.getRequestBody(), Batch.class);
+            List<Event> projectBatches = new ArrayList<>();
+            if (projectIdToBatches.containsKey(b.getProjectId())) {
+                projectBatches = projectIdToBatches.get(b.getProjectId());
+            }
+            projectBatches.add(new Event(event.second.getURL(), gson.toJson(b, Batch.class)));
+            projectIdToBatches.put(b.getProjectId(), projectBatches);
+        }
+
+        return projectIdToBatches;
+    }
+
+    Event mergeBatches(List<Event> batchEvents) {
+        // TODO THIS IS ALMOST CERTAINLY WRONG
+        URL url = null;
+        Batch mergedBatch = null;
+        for (Event batchEvent : batchEvents) {
+            Batch batch = gson.fromJson(batchEvent.getRequestBody(), Batch.class);
+            if (mergedBatch == null) {
+                url = batchEvent.getURL();
+                mergedBatch = batch;
+            } else {
+                for (Visitor visitor : batch.getVisitors()) {
+                    for (Snapshot snapshot : visitor.getSnapshots()) {
+                        Visitor mergedVisitor = mergedBatch.getVisitors().get(0);
+                        Set<Decision> decisionSet = new HashSet<>(mergedVisitor.getSnapshots().get(0).getDecisions());
+                        decisionSet.addAll(snapshot.getDecisions());
+                        Set<com.optimizely.ab.event.internal.payload.batch.Event> eventSet
+                                    = new HashSet<>(mergedVisitor.getSnapshots().get(0).getEvents());
+                        eventSet.addAll(snapshot.getEvents());
+                        Snapshot mergedSnapshot = mergedVisitor.getSnapshots().get(0);
+                        mergedSnapshot.setDecisions(new ArrayList<>(decisionSet));
+                        mergedSnapshot.setEvents(new ArrayList<>(eventSet));
+                    }
                 }
             }
         }
 
-        return events.isEmpty();
+        return new Event(url, gson.toJson(mergedBatch, Batch.class));
     }
 
-    /**
-     * Send a single event
-     *
-     * @param event an {@link Event} instance to attempt to dispatch
-     * @return true if event was sent to network, otherwise false if stored
-     */
-    private boolean dispatch(Event event) {
-        boolean eventWasSent = eventClient.sendEvent(event);
 
-        if (eventWasSent) {
-            CountingIdlingResourceManager.decrement();
-            CountingIdlingResourceManager.recordEvent(new Pair<>(event.getURL().toString(), event.getRequestBody()));
+    /**
+     * Store a singular batch event
+     *
+     * @param event an {@link Event} instance to store
+     * @return true if event was stored, otherwise false
+     */
+    private boolean store(Event event) {
+        boolean eventWasStored = eventDAO.storeEvent(event);
+        if (!eventWasStored) {
+            logger.error("Unable to store event {}", event);
             return true;
         } else {
-            boolean eventWasStored = eventDAO.storeEvent(event);
-            if (!eventWasStored) {
-                logger.error("Unable to send or store event {}", event);
-                // Return true since nothing was stored
-                return true;
-            } else {
-                return false;
-            }
+            return false;
         }
     }
 }

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/OptlyEventHandler.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/OptlyEventHandler.java
@@ -85,13 +85,28 @@ public class OptlyEventHandler implements EventHandler {
         }
 
         Intent intent = new Intent(context, EventIntentService.class);
+        intent.setAction(EventIntentService.ACTION_STORE);
         intent.putExtra(EventIntentService.EXTRA_URL, logEvent.getEndpointUrl());
         intent.putExtra(EventIntentService.EXTRA_REQUEST_BODY, logEvent.getBody());
+        context.startService(intent);
+        logger.info("Sent url {} to the event handler service", logEvent.getEndpointUrl());
+    }
+
+    public void schedule() {
+        Intent intent = new Intent(context, EventIntentService.class);
+        intent.setAction(EventIntentService.ACTION_SCHEDULE);
         if (dispatchInterval != -1) {
             intent.putExtra(EventIntentService.EXTRA_INTERVAL, dispatchInterval);
         }
         context.startService(intent);
-        logger.info("Sent url {} to the event handler service", logEvent.getEndpointUrl());
+        logger.info("Sent schedule intent to the event handler service");
+    }
 
+    public void flush() {
+        Intent intent = new Intent(context, EventIntentService.class);
+        intent.setAction(EventIntentService.ACTION_FLUSH);
+
+        context.startService(intent);
+        logger.info("Sent flush intent to the event handler service");
     }
 }

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventIntentServiceTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventIntentServiceTest.java
@@ -62,7 +62,7 @@ public class EventIntentServiceTest {
         EventDispatcher eventDispatcher = mock(EventDispatcher.class);
         service.eventDispatcher = eventDispatcher;
         service.onHandleIntent(intent);
-        verify(eventDispatcher).dispatch(intent);
+        verify(eventDispatcher).store(intent);
         verify(logger).info("Handled intent");
     }
 }

--- a/test-app/src/androidTest/java/com/optimizely/ab/android/test_app/MainActivityEspressoTest.java
+++ b/test-app/src/androidTest/java/com/optimizely/ab/android/test_app/MainActivityEspressoTest.java
@@ -50,13 +50,13 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
+// TODO these e2e tests are no longer working
 public class MainActivityEspressoTest {
 
     private Context context = InstrumentationRegistry.getTargetContext();


### PR DESCRIPTION
Reworks EventHandler implementation to merge and flush "singular batch" log events created from the batch version of Java X SDK.  https://github.com/optimizely/java-sdk/pull/99

Changes:

* Event dispatch to the network should not be attempted as soon as a event comes in
* Events (singular batches) should be stored as they come in
* When a users session ends a request is made the EventHandlerService to flush events
* The EventDispatcher takes all of the singular event batches in storage and merges them into one batch
* The merged batch is sent to the batch endpoint 
* If successfully sent the singular batches are removed from storage
* Flushing will still occur on an interval in the background to catch events not created during a session or if sending a batch failed.

TODO:
There is definitely a ton of work to do here still.  I am not confident in the merging function at all and is very simplistic.  I am sure there is a clever way to handle that.  Also, I have tested this end 2 end at all but it should be a nice guide to implementing batching on Android.