### PR TITLE
new config for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,10 +115,17 @@ workflows:
       - test_api_version_17:
           requires:
             - build
-      - deploy:
-          requires:
-            - test_api_version_17
-            - test_api_version_25
+  build-n-deploy:
+    jobs:
+      - build:
           filters:
             tags:
-              only: /.*/              
+              only: /.*/
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
This change enables publishing to bintray via a git tag by adding a new workflow.