### PR TITLE
fixing changelog to reflect 2.0.0 rollback and 2.0.0-beta2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Optimizely Android X SDK Changelog
 
-## 2.0.0
+## 2.0.0-beta2
 
-April 25th, 2018
+May 17, 2018
 
-This major release of the Optimizely SDK introduces APIs for Feature Management. It also introduces some breaking changes listed below.
+**This "-beta2" replaces the rolled-back 2.0.x release because of usability issues uncovered during the 2.0.x launch. Please note that 2.0+ SDKs are incompatible with existing 1.x Mobile Optimizely projects. Before you use 2.0+ and Feature Management, please contact your Optimizely account team. If you are not upgrading to Feature Management, we recommend remaining on your current 1.x SDK.**
 
 ### New Features
 * Introduces the `isFeatureEnabled` API to determine whether to show a feature to a user or not.


### PR DESCRIPTION
Simple changes to the changelog, which wasn't updated when we did the 2.0.0 rollback and 2.0.0-beta2 release