### PR TITLE
Add @Nullable annotation to getNotificationCenter()

### DIFF
--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyClient.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyClient.java
@@ -546,9 +546,11 @@ public class OptimizelyClient {
     /**
      * Return the notification center {@link NotificationCenter} used to add notifications for events
      * such as Activate and track.
-     * @return
+     * @return The {@link NotificationCenter} or null if Optimizely is not initialized (or
+     * initialization failed)
      */
-    public NotificationCenter getNotificationCenter() {
+    public @Nullable
+    NotificationCenter getNotificationCenter() {
         if (isValid()) {
             return optimizely.notificationCenter;
         } else {


### PR DESCRIPTION
In circumstances where initialisation fails, ``OptimizelyManager`` returns a dummy ``OptimizelyClient`` which has a null ``NotificationCenter``.

Adding this annotation warns SDK users that they shouldn’t rely on a ``@NonNull NotificationCenter`` being returned, for example if they call ``addActivateNotificationListener()`` after ``initialise()`` This bit a client of mine in production so hoping this will help other users.

Android Studio now displays appropriate warnings when calling this API from Java, including from the test app. In Kotlin though the following would not compile if this annotation is added:

``optimizelyClient.notificationCenter.addActivateNotificationListener(...)``
``Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type NotificationCenter``