### PR TITLE
(fix)wrap schedule in a try catch in case of too many scheduled jobs which…

### DIFF
--- a/shared/src/main/java/com/optimizely/ab/android/shared/ServiceScheduler.java
+++ b/shared/src/main/java/com/optimizely/ab/android/shared/ServiceScheduler.java
@@ -131,10 +131,14 @@ public class ServiceScheduler {
 
             builder.setExtras(persistableBundle);
 
-            if (jobScheduler.schedule(builder.build()) != RESULT_SUCCESS) {
-                logger.error("ServiceScheduler", "Some error while scheduling the job");
+            try {
+                if (jobScheduler.schedule(builder.build()) != RESULT_SUCCESS) {
+                    logger.error("ServiceScheduler", "Some error while scheduling the job");
+                }
             }
-
+            catch (Exception e) {
+                logger.error("Problem scheduling job ", e);
+            }
         }
         else {
             AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);


### PR DESCRIPTION
… throws an exception

wrap the job scheduler schedule in a try catch.  Customer is experiencing difficulty starting in the background and trying to schedule another background update causes a Illegal State Exception.  

This is not necessarily the SDK's fault but the exception should not stop the app.  So, we are wrapping the call with a try catch.

https://github.com/optimizely/android-sdk/issues/234