### PR TITLE
(chore) update changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,9 @@
 November 8, 2018
 
 This is a patch release.
-This release basically replaces 2.1.1 which was only partially released.
 
 ### Bug Fixes
-Filters out attributes with null values from the event payload (via upgrade to Optimizely Java SDK 2.1.3
-
-Fix Optimizely builder to user DatafileConfig instead of deprecated project id.
-
-Update packages for gson, Jackson, and slf4j.
-
-Update credits
-
-Fix job scheduler exception when scheduling a repeatable job in the background.
+Fix job scheduler exception when scheduling a repeatable job in the background ([#236](https://github.com/optimizely/android-sdk/pull/236)).
 
 ## 2.1.1
 October 3nd, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Optimizely Android X SDK Changelog
 
+## 2.1.2
+November 8, 2018
+
+This is a patch release.
+This release basically replaces 2.1.1 which was only partially released.
+
+### Bug Fixes
+Filters out attributes with null values from the event payload (via upgrade to Optimizely Java SDK 2.1.3
+
+Fix Optimizely builder to user DatafileConfig instead of deprecated project id.
+
+Update packages for gson, Jackson, and slf4j.
+
+Update credits
+
+Fix job scheduler exception when scheduling a repeatable job in the background.
+
 ## 2.1.1
 October 3nd, 2018
 


### PR DESCRIPTION
Update changelog.  This build needs to go out since 2.1.1 was not done properly. 