### PR TITLE
(fix) update to latest java sdk to wrap a try catch on file open in static …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Optimizely Android X SDK Changelog
 
+## 2.1.3
+December 6th, 2018
+
+This is a patch release.
+
+### Bug Fixes
+* upgrade to Optimizely Java SDK 2.1.4
+* fix/wrap in try catch for getting build version in static init which might crash ([#241](https://github.com/optimizely/java-sdk/pull/241))
+
 ## 2.1.2
 November 8, 2018
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
     build_tools_version = "27.0.0"
     min_sdk_version = 14
     target_sdk_version = 26
-    java_core_ver = "2.1.3"
+    java_core_ver = "2.1.4"
     android_logger_ver = "1.3.6"
     support_annotations_ver = "24.2.1"
     junit_ver = "4.12"


### PR DESCRIPTION
…init

## Summary
- Upgrade to Optimizely Java SDK 2.1.4 which puts a try catch around file open during static initialization.

The "why", or other context.

## Test plan

## Issues
