### PR TITLE
(fix): don't trim user profile service unless it has gotten to over 100 expe…

### DIFF
--- a/user-profile/src/main/java/com/optimizely/ab/android/user_profile/UserProfileCache.java
+++ b/user-profile/src/main/java/com/optimizely/ab/android/user_profile/UserProfileCache.java
@@ -185,11 +185,14 @@ class UserProfileCache {
             Map<String, Object> maps = memoryCache.get(userId);
             Map<String, Map<String, String>> experimentBucketMap =
                     (ConcurrentHashMap<String, Map<String, String>>) maps.get(experimentBucketMapKey);
-            for (String experimentId : experimentBucketMap.keySet()){
-                if (!validExperimentIds.contains(experimentId)) {
-                    experimentBucketMap.remove(experimentId);
+            if (experimentBucketMap != null && experimentBucketMap.keySet().size() > 100) {
+                for (String experimentId : experimentBucketMap.keySet()) {
+                    if (!validExperimentIds.contains(experimentId)) {
+                        experimentBucketMap.remove(experimentId);
+                    }
                 }
             }
+
         }
         diskCache.save(memoryCache);
     }


### PR DESCRIPTION
…riments.

## Summary
- If a experiment is paused it is removed from the ups.  This makes the ups not very useful if you pause an experiment to change allocation.

The "why", or other context.

## Test plan

## Issues
- 3945