### PR TITLE
(fix)UPS: don't trim unless over 100 experiments in user's UPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Optimizely Android X SDK Changelog
 
+## 2.1.4
+Feburary 8th, 2019
+
+This is a patch release.
+
+### Bug Fixes
+* fix User Profile Service.  Don't trim the user profile service unless there are over 100 experiments in a users UPS. This will be configurable in the future.
+
 ## 2.1.3
 December 6th, 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Feburary 8th, 2019
 This is a patch release.
 
 ### Bug Fixes
-* fix User Profile Service.  Don't trim the user profile service unless there are over 100 experiments in a users UPS. This will be configurable in the future.
+* Fix for User Profile Service.  Don't trim the user profile service unless there are over 100 experiments in a users UPS. This will be configurable in the future.
 
 ## 2.1.3
 December 6th, 2018

--- a/user-profile/src/main/java/com/optimizely/ab/android/user_profile/UserProfileCache.java
+++ b/user-profile/src/main/java/com/optimizely/ab/android/user_profile/UserProfileCache.java
@@ -185,11 +185,14 @@ class UserProfileCache {
             Map<String, Object> maps = memoryCache.get(userId);
             Map<String, Map<String, String>> experimentBucketMap =
                     (ConcurrentHashMap<String, Map<String, String>>) maps.get(experimentBucketMapKey);
-            for (String experimentId : experimentBucketMap.keySet()){
-                if (!validExperimentIds.contains(experimentId)) {
-                    experimentBucketMap.remove(experimentId);
+            if (experimentBucketMap != null && experimentBucketMap.keySet().size() > 100) {
+                for (String experimentId : experimentBucketMap.keySet()) {
+                    if (!validExperimentIds.contains(experimentId)) {
+                        experimentBucketMap.remove(experimentId);
+                    }
                 }
             }
+
         }
         diskCache.save(memoryCache);
     }


### PR DESCRIPTION
## Summary
- patch release 2.1.4

The "why", or other context.

