### PR TITLE
(feat): refactor gradle to use latest builds and to build for java 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
 # These parameters should match the parameters for build tools and sdk versions in the gradle file
  - ANDROID_BUILD_TOOLS=28.0.3 # should match gradle
  - ADB_INSTALL_TIMEOUT=5 # minutes
- - ANDROID_API=26 # api is same as gradle file
+ - ANDROID_API=28 # api is same as gradle file
  matrix:
  - EMULATOR_API=22
  - EMULATOR_API=21
@@ -34,6 +34,8 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+before_install:
+    - yes | sdkmanager "platforms;android-28"
 before_script:
   - echo $TRAVIS_BRANCH
   - echo $TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 env:
  global:
 # These parameters should match the parameters for build tools and sdk versions in the gradle file
- - ANDROID_BUILD_TOOLS=27.0.0 # should match gradle
+ - ANDROID_BUILD_TOOLS=28.0.3 # should match gradle
  - ADB_INSTALL_TIMEOUT=5 # minutes
  - ANDROID_API=26 # api is same as gradle file
  matrix:

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -48,8 +48,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     dexOptions {
@@ -65,6 +65,7 @@ dependencies {
     compile ("com.optimizely.ab:core-api:$java_core_ver") {
         exclude group: 'com.google.code.findbugs'
     }
+
     compile "com.android.support:support-annotations:$support_annotations_ver"
 
     testCompile "junit:junit:$junit_ver"
@@ -102,13 +103,14 @@ android.libraryVariants.all { variant ->
 
         title = "Optimizely X Android SDK"
 
-        options.links("http://docs.oracle.com/javase/7/docs/api/");
+        options.links("http://docs.oracle.com/javase/8/docs/api/");
         options.linksOffline("http://d.android.com/reference", "${android.sdkDirectory}/docs/reference");
 
-        // First add all of your dependencies to the classpath, then add the android jars
-        classpath += files(variant.javaCompile.classpath.files)
-        classpath += files(android.getBootClasspath())
-
+        doFirst {
+            // First add all of your dependencies to the classpath, then add the android jars
+            classpath += files(variant.javaCompile.classpath.files)
+            classpath += files(android.getBootClasspath())
+        }
         // We're excluding these generated files
         exclude '**/BuildConfig.java'
         exclude '**/R.java'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -49,10 +49,10 @@ allprojects {
 }
 
 ext {
-    compile_sdk_version = 26
-    build_tools_version = "27.0.0"
+    compile_sdk_version = 28
+    build_tools_version = "28.0.3"
     min_sdk_version = 14
-    target_sdk_version = 26
+    target_sdk_version = 28
     java_core_ver = "3.0.0-RC2"
     android_logger_ver = "1.3.6"
     support_annotations_ver = "24.2.1"

--- a/datafile-handler/build.gradle
+++ b/datafile-handler/build.gradle
@@ -46,8 +46,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 
@@ -89,13 +89,14 @@ android.libraryVariants.all { variant ->
 
         title = "Optimizely X Android Datafile Handler"
 
-        options.links("http://docs.oracle.com/javase/7/docs/api/");
+        options.links("http://docs.oracle.com/javase/8/docs/api/");
         options.linksOffline("http://d.android.com/reference", "${android.sdkDirectory}/docs/reference");
 
         // First add all of your dependencies to the classpath, then add the android jars
-        classpath += files(variant.javaCompile.classpath.files)
-        classpath += files(android.getBootClasspath())
-
+        doFirst {
+            classpath += files(variant.javaCompile.classpath.files)
+            classpath += files(android.getBootClasspath())
+        }
         // We're excluding these generated files
         exclude '**/BuildConfig.java'
         exclude '**/R.java'

--- a/event-handler/build.gradle
+++ b/event-handler/build.gradle
@@ -46,10 +46,10 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
-    buildToolsVersion '27.0.0'
+    buildToolsVersion '28.0.3'
 }
 
 dependencies {
@@ -90,13 +90,14 @@ android.libraryVariants.all { variant ->
 
         title = "Optimizely X Android Event Handler"
 
-        options.links("http://docs.oracle.com/javase/7/docs/api/");
+        options.links("http://docs.oracle.com/javase/8/docs/api/");
         options.linksOffline("http://d.android.com/reference", "${android.sdkDirectory}/docs/reference");
 
         // First add all of your dependencies to the classpath, then add the android jars
-        classpath += files(variant.javaCompile.classpath.files)
-        classpath += files(android.getBootClasspath())
-
+        doFirst {
+            classpath += files(variant.javaCompile.classpath.files)
+            classpath += files(android.getBootClasspath())
+        }
         // We're excluding these generated files
         exclude '**/BuildConfig.java'
         exclude '**/R.java'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 07 11:56:04 PST 2018
+#Mon Feb 11 13:52:51 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -46,10 +46,10 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
-    buildToolsVersion '27.0.0'
+    buildToolsVersion '28.0.1'
 }
 
 dependencies {
@@ -94,13 +94,14 @@ android.libraryVariants.all { variant ->
 
         title = "Optimizely X Android Shared"
 
-        options.links("http://docs.oracle.com/javase/7/docs/api/");
+        options.links("http://docs.oracle.com/javase/8/docs/api/");
         options.linksOffline("http://d.android.com/reference", "${android.sdkDirectory}/docs/reference");
 
         // First add all of your dependencies to the classpath, then add the android jars
-        classpath += files(variant.javaCompile.classpath.files)
-        classpath += files(android.getBootClasspath())
-
+        doFirst {
+            classpath += files(variant.javaCompile.classpath.files)
+            classpath += files(android.getBootClasspath())
+        }
         // We're excluding these generated files
         exclude '**/BuildConfig.java'
         exclude '**/R.java'

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -42,8 +42,8 @@ dependencies {
     }
 
     // compile 'com.optimizely.ab:android-sdk:1.0.0'
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.android.support:design:24.2.1'
+    compile 'com.android.support:appcompat-v7:28.0.0'
+    compile 'com.android.support:design:28.0.0'
     // EXAMPLE REPLACE noveogroup android-looger with slf4j-android logger
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-android
     compile group: 'org.slf4j', name: 'slf4j-android', version: '1.7.25'
@@ -57,7 +57,7 @@ dependencies {
     testCompile project(':android-sdk')
 
     androidTestCompile("com.android.support.test:runner:$support_test_runner_ver")
-    androidTestCompile "com.android.support:support-annotations:24.2.1"
+    androidTestCompile "com.android.support:support-annotations:28.0.0"
     // Set this dependency to use JUnit 4 rules
     androidTestCompile "com.android.support.test:rules:$support_test_runner_ver"
     // Set this dependency to build and run Espresso tests

--- a/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.java
+++ b/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.java
@@ -75,7 +75,7 @@ public class MyApplication extends Application {
          OptimizelyManager.Builder builder = OptimizelyManager.builder();
          optimizelyManager =  builder.withEventDispatchInterval(60L * 10L)
             .withDatafileDownloadInterval(60L * 10L)
-            .withSDKKey("6hmwpgZcRFp36wH5QLK8Sb")
+            .withSDKKey("FCnSegiEkRry9rhVMroit4")
             .build(getApplicationContext());
     }
 }

--- a/user-profile/build.gradle
+++ b/user-profile/build.gradle
@@ -46,8 +46,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 
@@ -93,9 +93,10 @@ android.libraryVariants.all { variant ->
         options.linksOffline("http://d.android.com/reference", "${android.sdkDirectory}/docs/reference");
 
         // First add all of your dependencies to the classpath, then add the android jars
-        classpath += files(variant.javaCompile.classpath.files)
-        classpath += files(android.getBootClasspath())
-
+        doFirst {
+            classpath += files(variant.javaCompile.classpath.files)
+            classpath += files(android.getBootClasspath())
+        }
         // We're excluding these generated files
         exclude '**/BuildConfig.java'
         exclude '**/R.java'


### PR DESCRIPTION
## Summary
- Upgrade to use latest build and tools.
- Compatibility is now at Java 1 8.

The "why", or other context.
Android SDK developers can use Kotlin from here on out.

## Test plan
- Tested with latest Java also at 1.8

Preparing for 3.0 release/