### PR TITLE
(chore): this upgrades to gradle 4.6 which seems to still work with our config…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 11 13:52:51 PST 2019
+#Fri Feb 15 06:30:36 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
…uration.

## Summary
- Upgrading our build tools.

## Test plan
Tested with normal build environment and Travis builds.

## Issues
There seems to be an issue with our configuration and gradle 4.10.  So, right now we can upgrade to 4.6 with Android gradle build tools at 3.2.1 (current is 3.3.1 which was just released).
