### PR TITLE
Fix: reported Issue 258

### DIFF
--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -58,7 +58,7 @@ dependencies {
         exclude group: 'com.google.code.findbugs'
     }
     implementation "com.google.code.gson:gson:$gson_ver"
-
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8'
     compileOnly group: 'org.slf4j', name: 'slf4j-android', version: '1.7.25'
 
     compileOnly  "com.android.support:support-annotations:$support_annotations_ver"


### PR DESCRIPTION
## Summary
- Added implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8' which will resolve the errors related to it.

## Issues
- [Issue 258](https://github.com/optimizely/android-sdk/issues/258)