### PR TITLE
Fix JacksonConfigParser$ProjectConfigModule proguard issue

### DIFF
--- a/proguard-rules.txt
+++ b/proguard-rules.txt
@@ -46,6 +46,7 @@
 # Safely ignore warnings about other libraries since we are using Gson
 -dontwarn com.fasterxml.jackson.**
 -dontwarn org.json.**
+-dontwarn com.optimizely.ab.config.parser.JacksonConfigParser$ProjectConfigModule
 
 # Annotations
 -dontwarn javax.annotation.**


### PR DESCRIPTION
## Summary
- This PR fixes issue #258 
- It added one line ProGuard rule to the file

## Test plan
1. Import the SDK to an android project
1. Compile your testing android project with code obfuscation using ProGuard. (The release build type should have this setting by default)
1. The test passes if you can see *BUILD SUCCESSFUL*, otherwise, test fails
## Issues
- Fixes #258 