### PR TITLE
(fix): Corrupt datafile cache fix

### DIFF
--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -277,8 +277,13 @@ public class OptimizelyManager {
     public String getDatafile(Context context,@RawRes Integer datafileRes){
         try {
             if (isDatafileCached(context)) {
-                return datafileHandler.loadSavedDatafile(context, datafileConfig);
-            } else if (datafileRes!=null) {
+                String datafile = datafileHandler.loadSavedDatafile(context, datafileConfig);
+                if (datafile != null) {
+                    return datafile;
+                }
+            }
+
+            if (datafileRes!=null) {
                 return loadRawResource(context, datafileRes);
             }else{
                 logger.error("Invalid datafile resource ID.");

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -283,7 +283,7 @@ public class OptimizelyManager {
                 }
             }
 
-            if (datafileRes!=null) {
+            if (datafileRes != null) {
                 return loadRawResource(context, datafileRes);
             }else{
                 logger.error("Invalid datafile resource ID.");

--- a/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileLoader.java
+++ b/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileLoader.java
@@ -116,7 +116,7 @@ public class DatafileLoader {
             if (!datafileCache.exists() || (datafileCache.exists() && datafileCache.load() == null)) {
                 // create a wrapper for application context default storage.
                 OptlyStorage storage = new OptlyStorage(this.datafileService.getApplicationContext());
-                // set the last modified for this url to 1 millisecond passed Jan 1, 1970.
+                // set the last modified for this url to 1 millisecond past Jan 1, 1970.
                 storage.saveLong(datafileUrl, 1);
             }
             String dataFile = datafileClient.request(datafileUrl);

--- a/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileLoader.java
+++ b/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileLoader.java
@@ -24,6 +24,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 
 import com.optimizely.ab.android.shared.DatafileConfig;
+import com.optimizely.ab.android.shared.OptlyStorage;
 
 import org.slf4j.Logger;
 
@@ -110,6 +111,12 @@ public class DatafileLoader {
 
         @Override
         protected String doInBackground(Void... params) {
+
+            if (!datafileCache.exists() || (datafileCache.exists() && datafileCache.load() == null)) {
+                // there is a problem with the cached datafile.  set last modified to 1970
+                OptlyStorage storage = new OptlyStorage(this.datafileService.getApplicationContext());
+                storage.saveLong(datafileUrl, 1);
+            }
             String dataFile = datafileClient.request(datafileUrl);
             if (dataFile != null && !dataFile.isEmpty()) {
                 if (datafileCache.exists()) {

--- a/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileLoader.java
+++ b/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileLoader.java
@@ -112,9 +112,11 @@ public class DatafileLoader {
         @Override
         protected String doInBackground(Void... params) {
 
+            // if there is a problem with the cached datafile, set last modified to 1970
             if (!datafileCache.exists() || (datafileCache.exists() && datafileCache.load() == null)) {
-                // there is a problem with the cached datafile.  set last modified to 1970
+                // create a wrapper for application context default storage.
                 OptlyStorage storage = new OptlyStorage(this.datafileService.getApplicationContext());
+                // set the last modified for this url to 1 millisecond passed Jan 1, 1970.
                 storage.saveLong(datafileUrl, 1);
             }
             String dataFile = datafileClient.request(datafileUrl);


### PR DESCRIPTION
## Summary
- If the cached datafile is removed or corrupted, and last modified has already been set, the app won't load.
- If loading synchronously there is a similar problem where the datafile cache exists but is corrupt, it will also fail to initialize.
## Issues
- #277 