### PR TITLE
(chore): using more reliable emulators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
  - ADB_INSTALL_TIMEOUT=5 # minutes
  - ANDROID_API=28 # api is same as gradle file
  matrix:
- - EMULATOR_API=21
+ - EMULATOR_API=23
  - EMULATOR_API=22
 android:
   components:


### PR DESCRIPTION
## Summary
- 22,23 are more reliable.
