### PR TITLE
travis(ci): use our own emulator wait script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
   - echo $TRAVIS_TAG
   - echo no | android create avd --force -n test -t android-$EMULATOR_API --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
-  - android-wait-for-emulator
+  - scripts/android-wait-for-emulator.sh
   - adb shell input keyevent 82 &
 addons:
   srcclr: true

--- a/scripts/android-wait-for-emulator.sh
+++ b/scripts/android-wait-for-emulator.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Originally written by Ralf Kistner <ralf@embarkmobile.com>, but placed in the public domain
+
+set +e
+
+bootanim=""
+failcounter=0
+#timeout_in_sec=360 # 6 minutes
+timeout_in_sec=900 # 15 minutes
+echo "Waiting for emulator to start"
+until [[ "$bootanim" =~ "stopped" ]]; do
+  bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`
+#echo bootanim=\`$bootanim\`
+  if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+    || "$bootanim" =~ "running" || "$bootanim" =~  "error: no emulators found" ]]; then
+    let "failcounter += 5"
+    echo -n "."
+    if [[ $failcounter -gt timeout_in_sec ]]; then
+      echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
+      exit 1
+    fi
+  fi
+  sleep 5
+done
+
+echo "Emulator is ready (took $failcounter seconds)"


### PR DESCRIPTION
## Summary
we replace travis's android-wait-for-emulator with our own version with a longer default wait time (15m)
