### PR TITLE
fix(jackson-databind): update version (pr to master)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: android
+# you MUST mention trusty https://docs.travis-ci.com/user/languages/android/
+dist: trusty
 env:
  global:
 # These parameters should match the parameters for build tools and sdk versions in the gradle file
@@ -40,7 +42,7 @@ before_script:
   - echo $TRAVIS_TAG
   - echo no | android create avd --force -n test -t android-$EMULATOR_API --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
-  - android-wait-for-emulator
+  - scripts/android-wait-for-emulator.sh
   - adb shell input keyevent 82 &
 addons:
   srcclr: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Optimizely Android X SDK Changelog
 
+## 3.1.1
+July 23rd, 2019
+
+### Bug Fixes:
+* SourceClear flagged jackson-databind 2.9.8 fixed in 2.9.9.1
+
 ## 3.1.0
 May 13th, 2019
 

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     androidTestImplementation "com.google.dexmaker:dexmaker-mockito:$dexmaker_ver"
     androidTestImplementation "com.noveogroup.android:android-logger:$android_logger_ver"
     androidTestImplementation "com.google.code.gson:gson:$gson_ver"
-    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:2.9.8"
+    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonversion"
 }
 
 uploadArchives {

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     target_sdk_version = 28
     java_core_ver = "3.2.0"
     android_logger_ver = "1.3.6"
-    jacksonversion= "2.9.8"
+    jacksonversion= "2.9.9.1"
     support_annotations_ver = "24.2.1"
     junit_ver = "4.12"
     mockito_ver = "1.9.5"

--- a/datafile-handler/build.gradle
+++ b/datafile-handler/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     androidTestImplementation "com.google.dexmaker:dexmaker:$dexmaker_ver"
     androidTestImplementation "com.google.dexmaker:dexmaker-mockito:$dexmaker_ver"
     androidTestImplementation "com.noveogroup.android:android-logger:$android_logger_ver"
-    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:2.9.8"
+    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonversion"
 }
 
 uploadArchives {

--- a/event-handler/build.gradle
+++ b/event-handler/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     androidTestImplementation "com.google.dexmaker:dexmaker:$dexmaker_ver"
     androidTestImplementation "com.google.dexmaker:dexmaker-mockito:$dexmaker_ver"
     androidTestImplementation "com.noveogroup.android:android-logger:$android_logger_ver"
-    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:2.9.8"
+    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonversion"
 }
 
 uploadArchives {

--- a/scripts/android-wait-for-emulator.sh
+++ b/scripts/android-wait-for-emulator.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Originally written by Ralf Kistner <ralf@embarkmobile.com>, but placed in the public domain
+
+set +e
+
+bootanim=""
+failcounter=0
+#timeout_in_sec=360 # 6 minutes
+timeout_in_sec=900 # 15 minutes
+echo "Waiting for emulator to start"
+until [[ "$bootanim" =~ "stopped" ]]; do
+  bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`
+#echo bootanim=\`$bootanim\`
+  if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+    || "$bootanim" =~ "running" || "$bootanim" =~  "error: no emulators found" ]]; then
+    let "failcounter += 5"
+    echo -n "."
+    if [[ $failcounter -gt timeout_in_sec ]]; then
+      echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
+      exit 1
+    fi
+  else
+    if [[ ! "$bootanim" =~ "stopped" ]]; then
+      echo "unexpected behavior from (adb -e shell getprop init.svc.bootanim): $bootanim"
+      exit 1
+    fi
+  fi
+  sleep 5
+done
+
+echo "Emulator is ready (took $failcounter seconds)"

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     androidTestImplementation "com.google.dexmaker:dexmaker:$dexmaker_ver"
     androidTestImplementation "com.google.dexmaker:dexmaker-mockito:$dexmaker_ver"
     androidTestImplementation "com.noveogroup.android:android-logger:$android_logger_ver"
-    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:2.9.8"
+    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonversion"
 }
 
 uploadArchives {

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-android
     implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.7.25'
     // EXAMPLE REPLACE gson json parsing with jackson-databind json parsing.
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "$jacksonversion"
 
     testImplementation "junit:junit:$junit_ver"
     testImplementation "org.mockito:mockito-core:$mockito_ver"
@@ -68,5 +68,5 @@ dependencies {
     // androidTestImplementation 'com.optimizely.ab:android-sdk:1.0.0'
     androidTestImplementation project(':android-sdk')
     androidTestImplementation project(path: ':shared')
-    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:2.9.8"
+    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonversion"
 }

--- a/user-profile/build.gradle
+++ b/user-profile/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     androidTestImplementation "com.google.dexmaker:dexmaker:$dexmaker_ver"
     androidTestImplementation "com.google.dexmaker:dexmaker-mockito:$dexmaker_ver"
     androidTestImplementation "com.noveogroup.android:android-logger:$android_logger_ver"
-    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:2.9.8"
+    androidTestImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonversion"
 }
 
 uploadArchives {


### PR DESCRIPTION
this brings the changes in the 3.1.1 release to the master branch

* fix(jackson-databind): update version

* chore: update changelog

* travis(ci): use our own emulator wait script

* more helpful output while waiting for emulator

* force trusty
