### PR TITLE
(fix): fix so that the job service will not run if there is no internet conn…

### DIFF
--- a/shared/src/main/java/com/optimizely/ab/android/shared/ServiceScheduler.java
+++ b/shared/src/main/java/com/optimizely/ab/android/shared/ServiceScheduler.java
@@ -270,7 +270,8 @@ public class ServiceScheduler {
             JobInfo jobInfo = new JobInfo.Builder(jobId,
                     new ComponentName(context, JobWorkService.class))
                     // schedule it to run any time between 1 - 5 minutes
-                    .setMinimumLatency(JobWorkService.ONE_MINUTE)
+                    .setMinimumLatency(0)
+                    .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
                     .setOverrideDeadline(5 * JobWorkService.ONE_MINUTE)
                     .build();
             JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);

--- a/test-app/src/main/AndroidManifest.xml
+++ b/test-app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.optimizely.ab.android.test_app">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.optimizely.ab.android.test_app">
 
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -31,7 +32,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:ignore="GoogleAppIndexingWarning">
         <service
             android:name=".NotificationService"
             android:exported="false" />


### PR DESCRIPTION
…ection (possibly causing ANR). Also, start job right away so for instance events are flushed faster (another customer request

## Summary
- Tweak the job item so that when a service is stated it starts right away (not repeating).
- Don't run the job item if there is no internet connection (also not repeating)/

The "why", or other context.

## Issues
- #294 