### PR TITLE
(fix): don't use deprecated java sdk methods

### DIFF
--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -500,14 +500,15 @@ public class OptimizelyManager {
 
         Optimizely.Builder builder = Optimizely.builder();
 
+        builder.withEventHandler(eventHandler);
+
         if (datafileHandler instanceof DefaultDatafileHandler) {
             DefaultDatafileHandler handler = (DefaultDatafileHandler)datafileHandler;
             handler.setDatafile(datafile);
             builder.withConfigManager(handler);
-            builder.withEventHandler(eventHandler);
         }
         else {
-            builder = Optimizely.builder(datafile, eventHandler);
+            builder.withDatafile(datafile);
         }
 
         builder.withClientEngine(clientEngine)

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
     build_tools_version = "28.0.3"
     min_sdk_version = 14
     target_sdk_version = 28
-    java_core_ver = "3.2.0"
+    java_core_ver = "3.2.1"
     android_logger_ver = "1.3.6"
     jacksonversion= "2.9.9.1"
     support_annotations_ver = "24.2.1"


### PR DESCRIPTION
## Summary
- Small fix to use Optimizely Java SDK 3.2.1 builder.withDatafile instead of deprecated methods.

## Issues
- "THING-1234" or "Fixes #123"