### PR TITLE
(fix): make protected method public

### DIFF
--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -163,7 +163,7 @@ public class OptimizelyManager {
     }
 
     /**
-     * Initialize Optimizely Synchronously using the datafile passed in while downloading the latest datafile in the background from the CDN to cache.
+     * Initialize Optimizely Synchronously using the datafile passed in.
      * It should be noted that even though it initiates a download of the datafile to cache, this method does not use that cached datafile.
      * You can always test if a datafile exists in cache with {@link #isDatafileCached(Context)}.
      * <p>
@@ -175,7 +175,7 @@ public class OptimizelyManager {
      * @param downloadToCache to check if datafile should get updated in cache after initialization.
      * @return an {@link OptimizelyClient} instance
      */
-    protected OptimizelyClient initialize(@NonNull Context context, @Nullable String datafile, boolean downloadToCache) {
+    public OptimizelyClient initialize(@NonNull Context context, @Nullable String datafile, boolean downloadToCache) {
         if (!isAndroidVersionSupported()) {
             return optimizelyClient;
         }


### PR DESCRIPTION
## Summary
- Some developers want to initialize with their datafile and not attempt a background update.  The android documentation does not mention background update of cache.  By making this method public, we can fix a github issue as well as make the flow diagram correct since one time background updates to cache will be optional. (this does not affect periodic downloads).

## Issues
- #300 