### PR TITLE
fix (proguard): moved slf4j proguard keep to sdk rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ This minor release updates the SDK to use the Optimizely Java SDK 3.2.1 which in
 ### Deprecated
 * DatafileHandler interface has been deprecated. In the future we will start using the ProjectConfigManager from the Java SDK mentioned above.
 
+## 3.1.2
+January 7th, 2020
+
+### Bug Fixes:
+* Add keep for log4j to proguard rules.
 
 ## 3.1.1
 July 23rd, 2019

--- a/proguard-rules.txt
+++ b/proguard-rules.txt
@@ -55,6 +55,7 @@
 
 # slf4j
 -dontwarn org.slf4j.**
+-keep class org.slf4j.** {*;}
 
 # Android Logger
 -keep class com.noveogroup.android.log.** { *; }

--- a/test-app/proguard-rules.pro
+++ b/test-app/proguard-rules.pro
@@ -40,7 +40,7 @@
 
 # slf4j
 #-dontwarn org.slf4j.**
--keep class org.slf4j.** {*;}
+#-keep class org.slf4j.** {*;}
 
 # Android Logger
 #-keep class com.noveogroup.android.log.** { *; }


### PR DESCRIPTION
## Summary
- Since it is required in a minify.  We can probably add this rule without too much complaint.

## Test plan
- I generated a signed release pack with minify to insure that everything still works
