### PR TITLE
(fix): Listener on task

### DIFF
--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -21,6 +21,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.res.Resources;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -346,14 +347,16 @@ public class OptimizelyManager {
             @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
             @Override
             public void onDatafileLoaded(@Nullable String datafile) {
-                // App is being used, i.e. in the foreground
-                if (datafile != null && !datafile.isEmpty()) {
-                    injectOptimizely(context, userProfileService, datafile);
-                } else {
-                    //if datafile is null than it should be able to take from cache and if not present
-                    //in Cache than should be able to get from raw data file
-                    injectOptimizely(context, userProfileService, getDatafile(context,datafileRes));
-                }
+                AsyncTask.execute(() -> {
+                    // App is being used, i.e. in the foreground
+                    if (datafile != null && !datafile.isEmpty()) {
+                        injectOptimizely(context, userProfileService, datafile);
+                    } else {
+                        //if datafile is null than it should be able to take from cache and if not present
+                        //in Cache than should be able to get from raw data file
+                        injectOptimizely(context, userProfileService, getDatafile(context,datafileRes));
+                    }
+                });
             }
         };
     }

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -21,7 +21,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.res.Resources;
-import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -286,12 +286,12 @@ public class OptimizelyManager {
      */
     public String getDatafile(Context context,@RawRes Integer datafileRes){
         try {
-            if (isDatafileCached(context)) {
-                String datafile = datafileHandler.loadSavedDatafile(context, datafileConfig);
-                if (datafile != null) {
-                    return datafile;
-                }
-            }
+//            if (isDatafileCached(context)) {
+//                String datafile = datafileHandler.loadSavedDatafile(context, datafileConfig);
+//                if (datafile != null) {
+//                    return datafile;
+//                }
+//            }
 
             if (datafileRes != null) {
                 return loadRawResource(context, datafileRes);
@@ -347,16 +347,11 @@ public class OptimizelyManager {
             @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
             @Override
             public void onDatafileLoaded(@Nullable String datafile) {
-                AsyncTask.execute(() -> {
-                    // App is being used, i.e. in the foreground
-                    if (datafile != null && !datafile.isEmpty()) {
-                        injectOptimizely(context, userProfileService, datafile);
-                    } else {
-                        //if datafile is null than it should be able to take from cache and if not present
-                        //in Cache than should be able to get from raw data file
-                        injectOptimizely(context, userProfileService, getDatafile(context,datafileRes));
-                    }
-                });
+                if (datafile != null && !datafile.isEmpty()) {
+                    injectOptimizely(context, userProfileService, datafile);
+                } else {
+                    injectOptimizely(context, userProfileService, getDatafile(context,datafileRes));
+                }
             }
         };
     }

--- a/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileLoader.java
+++ b/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileLoader.java
@@ -26,6 +26,7 @@ import android.support.annotation.RequiresApi;
 import com.optimizely.ab.android.shared.DatafileConfig;
 import com.optimizely.ab.android.shared.OptlyStorage;
 
+import org.json.JSONObject;
 import org.slf4j.Logger;
 
 import java.util.concurrent.Executor;
@@ -128,6 +129,12 @@ public class DatafileLoader {
                 }
                 if (!datafileCache.save(dataFile)) {
                     logger.warn("Unable to save new datafile");
+                }
+            }
+            else {
+                JSONObject jsonFile = datafileCache.load();
+                if (jsonFile != null) {
+                    dataFile = jsonFile.toString();
                 }
             }
 


### PR DESCRIPTION
## Summary
- Load the cached datafile in the datafile loader if the datafile is null from cdn.  This avoids loading the cached datafile in the onPostExecute of the datafile loader which is on the main thread.

## Issues
- #320 