### PR TITLE
Build with java-sdk 3.5.0-beta release.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ buildscript {
 
 allprojects {
     repositories {
-	mavenLocal()
-	jcenter()
+        mavenLocal()
+        jcenter()
         google()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+	mavenLocal()
+	jcenter()
         google()
     }
 }
@@ -53,7 +54,7 @@ ext {
     build_tools_version = "29.0.3"
     min_sdk_version = 14
     target_sdk_version = 29
-    java_core_ver = "3.4.3"
+    java_core_ver = "3.5.0-beta"
     android_logger_ver = "1.3.6"
     jacksonversion= "2.9.9.1"
     support_annotations_ver = "24.2.1"


### PR DESCRIPTION
## Summary
- Add mavenLocal() to supported repositories for local development
- Bump core SDK to 3.5.0-beta

Test the compilation and matrix support of latest Java SDK release candidate.
