### PR TITLE
fix: upgrade to 6.x gradle syntax for javadocs

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -115,7 +115,7 @@ android.libraryVariants.all { variant ->
 
         doFirst {
             // First add all of your dependencies to the classpath, then add the android jars
-            classpath += files(variant.javaCompileProvider.classpath.files)
+            classpath += files(variant.javaCompileProvider.get().classpath.files)
             classpath += files(android.getBootClasspath())
         }
         // We're excluding these generated files

--- a/datafile-handler/build.gradle
+++ b/datafile-handler/build.gradle
@@ -101,7 +101,7 @@ android.libraryVariants.all { variant ->
 
         // First add all of your dependencies to the classpath, then add the android jars
         doFirst {
-            classpath += files(variant.javaCompileProvider.classpath.files)
+            classpath += files(variant.javaCompileProvider.get().classpath.files)
             classpath += files(android.getBootClasspath())
         }
         // We're excluding these generated files

--- a/event-handler/build.gradle
+++ b/event-handler/build.gradle
@@ -102,7 +102,7 @@ android.libraryVariants.all { variant ->
 
         // First add all of your dependencies to the classpath, then add the android jars
         doFirst {
-            classpath += files(variant.javaCompileProvider.classpath.files)
+            classpath += files(variant.javaCompileProvider.get().classpath.files)
             classpath += files(android.getBootClasspath())
         }
         // We're excluding these generated files

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -105,7 +105,7 @@ android.libraryVariants.all { variant ->
 
         // First add all of your dependencies to the classpath, then add the android jars
         doFirst {
-            classpath += files(variant.javaCompileProvider.classpath.files)
+            classpath += files(variant.javaCompileProvider.get().classpath.files)
             classpath += files(android.getBootClasspath())
         }
         // We're excluding these generated files

--- a/user-profile/build.gradle
+++ b/user-profile/build.gradle
@@ -101,7 +101,7 @@ android.libraryVariants.all { variant ->
 
         // First add all of your dependencies to the classpath, then add the android jars
         doFirst {
-            classpath += files(variant.javaCompileProvider.classpath.files)
+            classpath += files(variant.javaCompileProvider.get().classpath.files)
             classpath += files(android.getBootClasspath())
         }
         // We're excluding these generated files


### PR DESCRIPTION
## Summary
- javadoc task was failing.  These changes are needed for releasing and building javadocs.

## Test plan
Needed for publish.  Published locally.
