### PR TITLE
ci: Run source clear before linting and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,10 @@ script:
 
 # Integration tests need to run first to reset the PR build status to pending
 stages:
+  - 'Source Clear'
   - 'Lint markdown files'
   - 'Integration tests'
   - 'Test'
-  - 'Source Clear'
 
 jobs:
   include:


### PR DESCRIPTION
Summary
-------
Stages run sequentially on Travis. If a stage fails, all the following stages are not executed. We execute source clear only on cron, and if due to any reason unit or integration tests fail, the source clear is not executed. Hence, moving source clear stage before tests. 


Test plan
---------
All unit tests must be passed. 
FSC must be passed.