### PR TITLE
fix: add line so test-app does not abort on lint errors

### DIFF
--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -6,6 +6,10 @@ android {
     compileSdkVersion compile_sdk_version
     buildToolsVersion build_tools_version
 
+    lintOptions {
+        abortOnError false
+    }
+
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion target_sdk_version


### PR DESCRIPTION
## Summary
- fresh builds will fail with lint errors in test-app.  suppress abort on failure.
