### PR TITLE
fix: remove erroneous error if project id and sdk key are null.

### DIFF
--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
@@ -21,13 +21,18 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.optimizely.ab.OptimizelyRuntimeException;
 import com.optimizely.ab.android.datafile_handler.DefaultDatafileHandler;
 import com.optimizely.ab.android.event_handler.DefaultEventHandler;
+import com.optimizely.ab.android.shared.DatafileConfig;
 import com.optimizely.ab.android.user_profile.DefaultUserProfileService;
 import com.optimizely.ab.error.ErrorHandler;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
+
+import java.util.concurrent.TimeUnit;
+
 import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 @RunWith(AndroidJUnit4.class)
@@ -64,6 +69,78 @@ public class OptimizelyManagerBuilderTest {
         assertNotNull(manager.getUserProfileService());
         assertNotNull(manager.getErrorHandler(InstrumentationRegistry.getInstrumentation().getTargetContext()));
         assertNotNull(manager.getEventHandler(InstrumentationRegistry.getInstrumentation().getTargetContext()));
+    }
+
+    @Test
+    public void testBuilderWithOutDatafileConfig() {
+        ErrorHandler errorHandler = new ErrorHandler() {
+            @Override
+            public <T extends OptimizelyRuntimeException> void handleError(T exception) throws T {
+                logger.error("Inside error handler", exception);
+            }
+        };
+
+        OptimizelyManager manager = OptimizelyManager.builder().withUserProfileService(DefaultUserProfileService.newInstance(testProjectId, InstrumentationRegistry.getInstrumentation().getTargetContext()))
+                .withDatafileDownloadInterval(30L, TimeUnit.MINUTES)
+                .withEventDispatchInterval(30L, TimeUnit.MINUTES)
+                .withDatafileHandler(new DefaultDatafileHandler())
+                .withErrorHandler(errorHandler)
+                .withEventHandler(DefaultEventHandler.getInstance(InstrumentationRegistry.getInstrumentation().getTargetContext()))
+                .withLogger(logger).build(InstrumentationRegistry.getInstrumentation().getTargetContext());
+
+        assertNull(manager);
+    }
+
+    @Test
+    public void testBuilderWithOutDatafileConfigWithSdkKey() {
+        ErrorHandler errorHandler = new ErrorHandler() {
+            @Override
+            public <T extends OptimizelyRuntimeException> void handleError(T exception) throws T {
+                logger.error("Inside error handler", exception);
+            }
+        };
+
+        OptimizelyManager manager = OptimizelyManager.builder().withUserProfileService(DefaultUserProfileService.newInstance(testProjectId, InstrumentationRegistry.getInstrumentation().getTargetContext()))
+                .withDatafileDownloadInterval(30L, TimeUnit.MINUTES)
+                .withEventDispatchInterval(30L, TimeUnit.MINUTES)
+                .withDatafileHandler(new DefaultDatafileHandler())
+                .withErrorHandler(errorHandler)
+                .withSDKKey("sdkKey7")
+                .withEventHandler(DefaultEventHandler.getInstance(InstrumentationRegistry.getInstrumentation().getTargetContext()))
+                .withLogger(logger).build(InstrumentationRegistry.getInstrumentation().getTargetContext());
+
+        assertNotNull(manager);
+        assertNotNull(manager.getDatafileHandler());
+        assertNotNull(manager.getUserProfileService());
+        assertNotNull(manager.getEventHandler(InstrumentationRegistry.getInstrumentation().getTargetContext()));
+
+        manager.stop(InstrumentationRegistry.getInstrumentation().getTargetContext());
+    }
+
+    @Test
+    public void testBuilderWithDatafileConfig() {
+        ErrorHandler errorHandler = new ErrorHandler() {
+            @Override
+            public <T extends OptimizelyRuntimeException> void handleError(T exception) throws T {
+                logger.error("Inside error handler", exception);
+            }
+        };
+
+        OptimizelyManager manager = OptimizelyManager.builder().withUserProfileService(DefaultUserProfileService.newInstance(testProjectId, InstrumentationRegistry.getInstrumentation().getTargetContext()))
+                .withDatafileDownloadInterval(30L, TimeUnit.MINUTES)
+                .withEventDispatchInterval(30L, TimeUnit.MINUTES)
+                .withDatafileHandler(new DefaultDatafileHandler())
+                .withErrorHandler(errorHandler)
+                .withDatafileConfig(new DatafileConfig(null, "sdkKey7"))
+                .withEventHandler(DefaultEventHandler.getInstance(InstrumentationRegistry.getInstrumentation().getTargetContext()))
+                .withLogger(logger).build(InstrumentationRegistry.getInstrumentation().getTargetContext());
+
+        assertNotNull(manager);
+        assertNotNull(manager.getDatafileHandler());
+        assertNotNull(manager.getUserProfileService());
+        assertNotNull(manager.getEventHandler(InstrumentationRegistry.getInstrumentation().getTargetContext()));
+
+        manager.stop(InstrumentationRegistry.getInstrumentation().getTargetContext());
     }
 
     @Test

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -907,6 +907,11 @@ public class OptimizelyManager {
             }
 
             if (datafileConfig == null) {
+                if (projectId == null && sdkKey == null) {
+                    logger.error("ProjectId and SDKKey cannot both be null");
+                    return null;
+                }
+
                 datafileConfig = new DatafileConfig(projectId, sdkKey);
             }
 
@@ -915,8 +920,7 @@ public class OptimizelyManager {
             }
 
             if (userProfileService == null) {
-                DatafileConfig config = new DatafileConfig(projectId, sdkKey);
-                userProfileService = DefaultUserProfileService.newInstance(config.getKey(), context);
+                userProfileService = DefaultUserProfileService.newInstance(datafileConfig.getKey(), context);
             }
 
             if (eventHandler == null) {
@@ -934,11 +938,6 @@ public class OptimizelyManager {
                     .withFlushInterval(eventFlushInterval)
                     .build();
 
-            }
-
-            if (projectId == null && sdkKey == null) {
-                logger.error("ProjectId and SDKKey cannot both be null");
-                return null;
             }
 
             return new OptimizelyManager(projectId, sdkKey,


### PR DESCRIPTION
## Summary
-  move check to datafileConfig check.
-  simple change.
## Tests
- Added unit tests to builder test.
## Issues
- "Fixes #355 "