### PR TITLE
chore: add -no-audio to travis emulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - echo $TRAVIS_BRANCH
   - echo $TRAVIS_TAG
   - echo no | android create avd --force -n test -t android-$EMULATOR_API --abi $ANDROID_ABI
-  - emulator -avd test -no-window &
+  - emulator -avd test -no-audio -no-window &
   - scripts/android-wait-for-emulator.sh
   - adb shell input keyevent 82 &
 script:


### PR DESCRIPTION
## Summary
- add -no-audio to travis emulator (emulator boot up sometimes fails for API-24 in travis without this option)
