### PR TITLE
fix: support arbitrarily long list of user attributes in batch events

### DIFF
--- a/event-handler/build.gradle
+++ b/event-handler/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
     testImplementation "junit:junit:$junit_ver"
     testImplementation "org.mockito:mockito-core:$mockito_ver"
+    testImplementation "org.powermock:powermock-mockito-release-full:$powermock_ver"
     testImplementation "com.noveogroup.android:android-logger:$android_logger_ver"
 
     androidTestImplementation "androidx.test.ext:junit:$androidx_test"

--- a/event-handler/build.gradle
+++ b/event-handler/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     api project(':shared')
     implementation "androidx.annotation:annotation:$annotations_ver"
     implementation "androidx.work:work-runtime:$work_runtime"
+    // Base64
+    implementation "org.apache.commons:commons-collections4:4.1"
 
     compileOnly "com.noveogroup.android:android-logger:$android_logger_ver"
 

--- a/event-handler/build.gradle
+++ b/event-handler/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation "androidx.annotation:annotation:$annotations_ver"
     implementation "androidx.work:work-runtime:$work_runtime"
     // Base64
-    implementation "org.apache.commons:commons-collections4:4.1"
+    implementation "commons-codec:commons-codec:1.15"
 
     compileOnly "com.noveogroup.android:android-logger:$android_logger_ver"
 

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
@@ -23,65 +23,10 @@ public class EventHandlerUtils {
     private static final int BUFFER_SIZE = 32*1024;
 
     public static byte[] compress(@NonNull String uncompressed) throws IOException {
-        return compress(uncompressed, 1);
-    }
-    public static String decompress(@NonNull byte[] data) throws Exception {
-        return decompress(data, 1);
-    }
-
-
-    public static byte[] compress(@NonNull String uncompressed, int idx) throws IOException {
-        if (idx==1) {
-            return compress_1(uncompressed);
-        } else if (idx==2) {
-            return compress_2(uncompressed);
-        } else {
-            return compress_3(uncompressed);
-        }
-    }
-
-    public static String decompress(@NonNull byte[] data, int idx) throws Exception {
-        if (idx==1) {
-            return decompress_1(data);
-        } else if (idx==2) {
-            return decompress_2(data);
-        } else {
-            return decompress_3(data);
-        }
-    }
-
-     public static byte[] compress_1(@NonNull String uncompressed) throws IOException {
-        ByteArrayOutputStream os = new ByteArrayOutputStream(uncompressed.length());
-        GZIPOutputStream gos = new GZIPOutputStream(os);
-        gos.write(uncompressed.getBytes());
-        gos.close();
-        byte[] compressed = os.toByteArray();
-        os.close();
-        return compressed;
-    }
-
-    public static String decompress_1(@NonNull byte[] compressed) throws IOException {
-        //final int BUFFER_SIZE = 32;
-        final int BUFFER_SIZE = 32*1024;
-
-        ByteArrayInputStream is = new ByteArrayInputStream(compressed);
-        GZIPInputStream gis = new GZIPInputStream(is, BUFFER_SIZE);
-        StringBuilder uncompressed = new StringBuilder();
-        byte[] data = new byte[BUFFER_SIZE];
-        int bytesRead;
-        while ((bytesRead = gis.read(data)) != -1) {
-            uncompressed.append(new String(data, 0, bytesRead));
-        }
-        gis.close();
-        is.close();
-        return uncompressed.toString();
-    }
-
-    public static byte[] compress_2(@NonNull String uncompressed) throws IOException {
         byte[] data = uncompressed.getBytes();
 
         final Deflater deflater = new Deflater();
-        deflater.setLevel(BEST_COMPRESSION);
+        //deflater.setLevel(BEST_COMPRESSION);
         deflater.setInput(data);
 
         try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {
@@ -96,7 +41,7 @@ public class EventHandlerUtils {
         }
     }
 
-    public static String decompress_2(@NonNull byte[] data) throws Exception {
+    public static String decompress(@NonNull byte[] data) throws Exception {
         final Inflater inflater = new Inflater();
         inflater.setInput(data);
 
@@ -109,29 +54,6 @@ public class EventHandlerUtils {
 
             return outputStream.toString();
         }
-    }
-
-    public static byte[] compress_3(@NonNull String uncompressed) throws IOException {
-        byte[] input = uncompressed.getBytes();
-
-        byte[] output = new byte[100];
-        Deflater compresser = new Deflater();
-        compresser.setInput(input);
-        compresser.finish();
-        int compressedDataLength = compresser.deflate(output);
-        compresser.end();
-
-        return output;
-    }
-
-    public static String decompress_3(@NonNull byte[] data) throws Exception {
-        Inflater decompresser = new Inflater();
-        decompresser.setInput(data, 0, data.length);
-        byte[] result = new byte[100];
-        int resultLength = decompresser.inflate(result);
-        decompresser.end();
-
-        return new String(result, Charset.forName("UTF-8"));
     }
 
 }

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
@@ -8,6 +8,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 
+import org.apache.commons.codec.binary.Base64;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -22,7 +24,7 @@ public class EventHandlerUtils {
 
     private static final int BUFFER_SIZE = 32*1024;
 
-    public static byte[] compress(@NonNull String uncompressed) throws IOException {
+    public static String compress(@NonNull String uncompressed) throws IOException {
         byte[] data = uncompressed.getBytes();
 
         final Deflater deflater = new Deflater();
@@ -37,11 +39,16 @@ public class EventHandlerUtils {
                 outputStream.write(buffer, 0, count);
             }
 
-            return outputStream.toByteArray();
+            byte[] bytes = outputStream.toByteArray();
+            // encoded to Base64 (instead of byte[] since WorkManager.Data size is unexpectedly expanded with byte[]).
+            // - org.apache.commons.Base64 is used (instead of android.util.Base64) for unit testing
+            return Base64.encodeBase64String(bytes);
         }
     }
 
-    public static String decompress(@NonNull byte[] data) throws Exception {
+    public static String decompress(@NonNull String base64) throws Exception {
+        byte[] data = Base64.decodeBase64(base64);
+
         final Inflater inflater = new Inflater();
         inflater.setInput(data);
 

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
@@ -1,17 +1,56 @@
 package com.optimizely.ab.android.event_handler;
 
+import static java.util.zip.Deflater.BEST_COMPRESSION;
+
+import android.os.Build;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.Deflater;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import java.util.zip.Inflater;
 
 public class EventHandlerUtils {
 
+    private static final int BUFFER_SIZE = 32*1024;
+
     public static byte[] compress(@NonNull String uncompressed) throws IOException {
+        return compress(uncompressed, 1);
+    }
+    public static String decompress(@NonNull byte[] data) throws Exception {
+        return decompress(data, 1);
+    }
+
+
+    public static byte[] compress(@NonNull String uncompressed, int idx) throws IOException {
+        if (idx==1) {
+            return compress_1(uncompressed);
+        } else if (idx==2) {
+            return compress_2(uncompressed);
+        } else {
+            return compress_3(uncompressed);
+        }
+    }
+
+    public static String decompress(@NonNull byte[] data, int idx) throws Exception {
+        if (idx==1) {
+            return decompress_1(data);
+        } else if (idx==2) {
+            return decompress_2(data);
+        } else {
+            return decompress_3(data);
+        }
+    }
+
+     public static byte[] compress_1(@NonNull String uncompressed) throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream(uncompressed.length());
         GZIPOutputStream gos = new GZIPOutputStream(os);
         gos.write(uncompressed.getBytes());
@@ -21,7 +60,7 @@ public class EventHandlerUtils {
         return compressed;
     }
 
-    public static String uncompress(@NonNull byte[] compressed) throws IOException {
+    public static String decompress_1(@NonNull byte[] compressed) throws IOException {
         //final int BUFFER_SIZE = 32;
         final int BUFFER_SIZE = 32*1024;
 
@@ -36,6 +75,63 @@ public class EventHandlerUtils {
         gis.close();
         is.close();
         return uncompressed.toString();
+    }
+
+    public static byte[] compress_2(@NonNull String uncompressed) throws IOException {
+        byte[] data = uncompressed.getBytes();
+
+        final Deflater deflater = new Deflater();
+        deflater.setLevel(BEST_COMPRESSION);
+        deflater.setInput(data);
+
+        try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {
+            deflater.finish();
+            final byte[] buffer = new byte[BUFFER_SIZE];
+            while (!deflater.finished()) {
+                final int count = deflater.deflate(buffer);
+                outputStream.write(buffer, 0, count);
+            }
+
+            return outputStream.toByteArray();
+        }
+    }
+
+    public static String decompress_2(@NonNull byte[] data) throws Exception {
+        final Inflater inflater = new Inflater();
+        inflater.setInput(data);
+
+        try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            while (!inflater.finished()) {
+                final int count = inflater.inflate(buffer);
+                outputStream.write(buffer, 0, count);
+            }
+
+            return outputStream.toString();
+        }
+    }
+
+    public static byte[] compress_3(@NonNull String uncompressed) throws IOException {
+        byte[] input = uncompressed.getBytes();
+
+        byte[] output = new byte[100];
+        Deflater compresser = new Deflater();
+        compresser.setInput(input);
+        compresser.finish();
+        int compressedDataLength = compresser.deflate(output);
+        compresser.end();
+
+        return output;
+    }
+
+    public static String decompress_3(@NonNull byte[] data) throws Exception {
+        Inflater decompresser = new Inflater();
+        decompresser.setInput(data, 0, data.length);
+        byte[] result = new byte[100];
+        int resultLength = decompresser.inflate(result);
+        decompresser.end();
+
+        return new String(result, Charset.forName("UTF-8"));
     }
 
 }

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
@@ -41,13 +41,12 @@ public class EventHandlerUtils {
 
             byte[] bytes = outputStream.toByteArray();
             // encoded to Base64 (instead of byte[] since WorkManager.Data size is unexpectedly expanded with byte[]).
-            // - org.apache.commons.Base64 is used (instead of android.util.Base64) for unit testing
-            return Base64.encodeBase64String(bytes);
+            return encodeToBase64(bytes);
         }
     }
 
     public static String decompress(@NonNull String base64) throws Exception {
-        byte[] data = Base64.decodeBase64(base64);
+        byte[] data = decodeFromBase64(base64);
 
         final Inflater inflater = new Inflater();
         inflater.setInput(data);
@@ -61,6 +60,21 @@ public class EventHandlerUtils {
 
             return outputStream.toString();
         }
+    }
+
+    static String encodeToBase64(byte[] bytes) {
+        // - org.apache.commons.Base64 is used (instead of android.util.Base64) for unit testing
+        // - encodeBase64() for backward compatibility (instead of encodeBase64String()).
+        String base64 = "";
+        if (bytes != null) {
+            byte[] encoded = Base64.encodeBase64(bytes);
+            base64= new String(encoded);
+        }
+        return base64;
+    }
+
+    static byte[] decodeFromBase64(String base64) {
+        return Base64.decodeBase64(base64.getBytes());
     }
 
 }

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
@@ -1,0 +1,39 @@
+package com.optimizely.ab.android.event_handler;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class EventHandlerUtils {
+
+    public static byte[] compress(@NonNull String uncompressed) throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream(uncompressed.length());
+        GZIPOutputStream gos = new GZIPOutputStream(os);
+        gos.write(uncompressed.getBytes());
+        gos.close();
+        byte[] compressed = os.toByteArray();
+        os.close();
+        return compressed;
+    }
+
+    public static String uncompress(@NonNull byte[] compressed) throws IOException {
+        final int BUFFER_SIZE = 32;
+        ByteArrayInputStream is = new ByteArrayInputStream(compressed);
+        GZIPInputStream gis = new GZIPInputStream(is, BUFFER_SIZE);
+        StringBuilder uncompressed = new StringBuilder();
+        byte[] data = new byte[BUFFER_SIZE];
+        int bytesRead;
+        while ((bytesRead = gis.read(data)) != -1) {
+            uncompressed.append(new String(data, 0, bytesRead));
+        }
+        gis.close();
+        is.close();
+        return uncompressed.toString();
+    }
+
+}

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
@@ -22,7 +22,9 @@ public class EventHandlerUtils {
     }
 
     public static String uncompress(@NonNull byte[] compressed) throws IOException {
-        final int BUFFER_SIZE = 32;
+        //final int BUFFER_SIZE = 32;
+        final int BUFFER_SIZE = 32*1024;
+
         ByteArrayInputStream is = new ByteArrayInputStream(compressed);
         GZIPInputStream gis = new GZIPInputStream(is, BUFFER_SIZE);
         StringBuilder uncompressed = new StringBuilder();

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventWorker.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventWorker.java
@@ -87,8 +87,8 @@ public class EventWorker extends Worker {
     @VisibleForTesting
     public static Data compressEvent(String url, String body) {
         try {
-            byte[] bodyArray = EventHandlerUtils.compress(body);
-            return dataForCompressedEvent(url, bodyArray);
+            byte[] compressed = EventHandlerUtils.compress(body);
+            return dataForCompressedEvent(url, compressed);
         } catch (Exception e) {
             return dataForEvent(url, body);
         }
@@ -103,10 +103,10 @@ public class EventWorker extends Worker {
     }
 
     @VisibleForTesting
-    public static Data dataForCompressedEvent(String url, byte[] bodyArray) {
+    public static Data dataForCompressedEvent(String url, byte[] compressed) {
         return new Data.Builder()
                 .putString("url", url)
-                .putByteArray("bodyArray", bodyArray)
+                .putByteArray("bodyCompressed", compressed)
                 .build();
     }
 
@@ -120,7 +120,7 @@ public class EventWorker extends Worker {
 
         // check if data compressed
 
-        byte[] byteArray = inputData.getByteArray("bodyArray");
+        byte[] byteArray = inputData.getByteArray("bodyCompressed");
         try {
             return EventHandlerUtils.decompress(byteArray);
         } catch (Exception e) {

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventWorker.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventWorker.java
@@ -122,7 +122,7 @@ public class EventWorker extends Worker {
 
         byte[] byteArray = inputData.getByteArray("bodyArray");
         try {
-            return EventHandlerUtils.uncompress(byteArray);
+            return EventHandlerUtils.decompress(byteArray);
         } catch (Exception e) {
             return null;
         }

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventWorker.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventWorker.java
@@ -87,7 +87,7 @@ public class EventWorker extends Worker {
     @VisibleForTesting
     public static Data compressEvent(String url, String body) {
         try {
-            byte[] compressed = EventHandlerUtils.compress(body);
+            String compressed = EventHandlerUtils.compress(body);
             return dataForCompressedEvent(url, compressed);
         } catch (Exception e) {
             return dataForEvent(url, body);
@@ -103,10 +103,10 @@ public class EventWorker extends Worker {
     }
 
     @VisibleForTesting
-    public static Data dataForCompressedEvent(String url, byte[] compressed) {
+    public static Data dataForCompressedEvent(String url, String compressed) {
         return new Data.Builder()
                 .putString("url", url)
-                .putByteArray("bodyCompressed", compressed)
+                .putString("bodyCompressed", compressed)
                 .build();
     }
 
@@ -120,9 +120,9 @@ public class EventWorker extends Worker {
 
         // check if data compressed
 
-        byte[] byteArray = inputData.getByteArray("bodyCompressed");
+        String compressed = inputData.getString("bodyCompressed");
         try {
-            return EventHandlerUtils.decompress(byteArray);
+            return EventHandlerUtils.decompress(compressed);
         } catch (Exception e) {
             return null;
         }

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
@@ -1,0 +1,43 @@
+package com.optimizely.ab.android.event_handler;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.work.Data;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class EventHandlerUtilsTest {
+
+    @Test
+    public void compressAndUncompress() throws IOException {
+        String str = makeRandomString(1000);
+
+        byte[] compressed = EventHandlerUtils.compress(str);
+        assert(compressed.length < (str.length() * 0.5));
+
+        String uncompressed = EventHandlerUtils.uncompress(compressed);
+        assertEquals(str, uncompressed);
+    }
+
+    public static String makeRandomString(int maxSize) {
+        StringBuilder builder = new StringBuilder();
+
+        // for high compression rate, pick from a small set
+        int[] randoms = {1000000, 1000001, 1000002};
+
+        int size = 0;
+        for(int i=0;; i++) {
+            String str = String.valueOf(randoms[i%3]);
+            size += str.length();
+            if (size > maxSize) {
+                break;
+            }
+            builder.append(str);
+        }
+
+        return builder.toString();
+    }
+
+}

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
@@ -52,11 +52,11 @@ public class EventHandlerUtilsTest {
         StringBuilder builder = new StringBuilder();
 
         // for high compression rate, pick from a small set
-        int[] randoms = {1000000, 1000001, 1000002};
+        int[] randoms = {100001, 100002, 100003};
 
         int size = 0;
         for(int i=0;; i++) {
-            String str = String.valueOf(randoms[i%3]);
+            String str = String.valueOf(randoms[i%randoms.length]);
             size += str.length();
             if (size > maxSize) {
                 break;

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
@@ -21,6 +21,33 @@ public class EventHandlerUtilsTest {
         assertEquals(str, uncompressed);
     }
 
+    @Test(timeout=30000)
+    public void measureCompressionDelay() throws Exception {
+        int maxEventSize = 100000;  // 100KB (~100 attributes)
+        int count = 3000;
+
+        String body = EventHandlerUtilsTest.makeRandomString(maxEventSize);
+
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < count; i++) {
+            EventHandlerUtils.compress(body);
+        }
+        long end = System.currentTimeMillis();
+        float delayCompress = ((float)(end - start))/count;
+        System.out.println("Compression Delay: " + String.valueOf(delayCompress) + " millisecs");
+        assert(delayCompress < 10);   // less than 1ms for 100KB (set 10ms upperbound)
+
+        start = System.currentTimeMillis();
+        for (int i = 0; i < count; i++) {
+            byte[] byteArray = EventHandlerUtils.compress(body);
+            EventHandlerUtils.decompress(byteArray);
+        }
+        end = System.currentTimeMillis();
+        float delayUncompress = ((float)(end - start))/count - delayCompress;
+        System.out.println("Uncompression Delay: " + String.valueOf(delayUncompress) + " millisecs");
+        assert(delayUncompress < 10);  // less than 1ms for 100KB (set 10ms upperbound)
+    }
+
     public static String makeRandomString(int maxSize) {
         StringBuilder builder = new StringBuilder();
 

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
@@ -11,13 +11,13 @@ import java.io.IOException;
 public class EventHandlerUtilsTest {
 
     @Test
-    public void compressAndUncompress() throws IOException {
+    public void compressAndUncompress() throws Exception {
         String str = makeRandomString(1000);
 
         byte[] compressed = EventHandlerUtils.compress(str);
         assert(compressed.length < (str.length() * 0.5));
 
-        String uncompressed = EventHandlerUtils.uncompress(compressed);
+        String uncompressed = EventHandlerUtils.decompress(compressed);
         assertEquals(str, uncompressed);
     }
 

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
@@ -51,17 +51,29 @@ public class EventHandlerUtilsTest {
     public static String makeRandomString(int maxSize) {
         StringBuilder builder = new StringBuilder();
 
-        // for high compression rate, pick from a small set
-        int[] randoms = {100001, 100002, 100003};
+        // for high compression rate, shift repeated string window.
+        int window = 100;
+        int shift = 3;  // adjust (1...10) this for compression rate. smaller for higher rates.
+
+        int start = 0;
+        int end = start + window;
+        int i = 0;
 
         int size = 0;
-        for(int i=0;; i++) {
-            String str = String.valueOf(randoms[i%randoms.length]);
+        while (true) {
+            String str = String.valueOf(i);
             size += str.length();
             if (size > maxSize) {
                 break;
             }
             builder.append(str);
+
+            i++;
+            if (i > end) {
+                start = start + shift;
+                end = start + window;
+                i = start;
+            }
         }
 
         return builder.toString();

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventHandlerUtilsTest.java
@@ -14,8 +14,8 @@ public class EventHandlerUtilsTest {
     public void compressAndUncompress() throws Exception {
         String str = makeRandomString(1000);
 
-        byte[] compressed = EventHandlerUtils.compress(str);
-        assert(compressed.length < (str.length() * 0.5));
+        String compressed = EventHandlerUtils.compress(str);
+        assert(compressed.length() < (str.length() * 0.5));
 
         String uncompressed = EventHandlerUtils.decompress(compressed);
         assertEquals(str, uncompressed);
@@ -39,8 +39,8 @@ public class EventHandlerUtilsTest {
 
         start = System.currentTimeMillis();
         for (int i = 0; i < count; i++) {
-            byte[] byteArray = EventHandlerUtils.compress(body);
-            EventHandlerUtils.decompress(byteArray);
+            String compressed = EventHandlerUtils.compress(body);
+            EventHandlerUtils.decompress(compressed);
         }
         end = System.currentTimeMillis();
         float delayUncompress = ((float)(end - start))/count - delayCompress;

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventWorkerTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventWorkerTest.java
@@ -1,0 +1,188 @@
+/****************************************************************************
+ * Copyright 2021, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package com.optimizely.ab.android.event_handler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import android.app.Instrumentation;
+import android.content.Context;
+
+import androidx.work.Data;
+import androidx.work.WorkerParameters;
+
+import com.optimizely.ab.event.LogEvent;
+import com.optimizely.ab.event.internal.payload.EventBatch;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+/**
+ * Tests {@link EventWorker}
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ EventWorker.class, EventHandlerUtils.class, WorkerParameters.class })
+@PowerMockIgnore("jdk.internal.reflect.*")
+public class EventWorkerTest {
+
+    private EventWorker eventWorker = new EventWorker(mock(Context.class), PowerMockito.mock(WorkerParameters.class));
+
+    private String host = "http://www.foo.com";
+    private LogEvent emptyEvent = new LogEvent(LogEvent.RequestMethod.POST, host, new HashMap<String, String>(), new EventBatch());
+
+    @Test
+    public void dataForEvent() {
+        Data data1 = EventWorker.dataForEvent(host, "body-string");
+        assertEquals(data1.getString("url"), host);
+        assertEquals(data1.getString("body"), "body-string");
+        assertNull(data1.getByteArray("bodyArray"));
+
+        Data data2 = EventWorker.dataForEvent(emptyEvent);
+        assertEquals(data2.getString("url"), host);
+        assertEquals(data2.getString("body"), "{}");
+        assertNull(data1.getByteArray("bodyArray"));
+    }
+
+    @Test
+    public void dataForCompressedEvent() {
+        byte[] byteArray = "body-string".getBytes();
+        Data data = EventWorker.dataForCompressedEvent(host, byteArray);
+        assertEquals(data.getString("url"), host);
+        assertArrayEquals(data.getByteArray("bodyArray"), byteArray);
+        assertNull(data.getString("body"));
+    }
+
+    @Test
+    public void compressEvent() throws IOException {
+        byte[] bodyArray = "any-string".getBytes();
+
+        PowerMockito.mockStatic(EventHandlerUtils.class);
+        when(EventHandlerUtils.compress(anyString())).thenReturn(bodyArray);
+
+        Data data = EventWorker.compressEvent(emptyEvent);
+        assertEquals(data.getString("url"), host);
+        assertArrayEquals(data.getByteArray("bodyArray"), bodyArray);
+        assertNull(data.getString("body"));
+    }
+
+    @Test
+    public void compressEventWithCompressionFailure() throws IOException {
+        PowerMockito.mockStatic(EventHandlerUtils.class);
+        PowerMockito.doThrow(new IOException()).when(EventHandlerUtils.class);
+        EventHandlerUtils.compress(anyString());  // PowerMockito throws exception on this static method
+
+        Data data = EventWorker.compressEvent(emptyEvent);
+        assertEquals(data.getString("url"), host);
+        assertEquals(data.getString("body"), "{}");
+        assertNull(data.getByteArray("bodyArray"));
+    }
+
+    @Test
+    public void getDataWithSmallEvent() throws IOException {
+        LogEvent mockEvent = Mockito.mock(LogEvent.class);
+        when(mockEvent.getEndpointUrl()).thenReturn(host);
+
+        int[] sizes = {100, 8000, 9000};
+        for (int size : sizes){
+            String str = EventHandlerUtilsTest.makeRandomString(size);
+
+            when(mockEvent.getBody()).thenReturn(str);
+
+            Data data = EventWorker.getData(mockEvent);
+            assertEquals(data.getString("url"), host);
+            assertEquals(data.getString("body"), str);
+            assertNull(data.getByteArray("bodyArray"));
+        }
+    }
+
+    @Test
+    public void getDataWithLargeEvent() throws IOException {
+        LogEvent mockEvent = Mockito.mock(LogEvent.class);
+        when(mockEvent.getEndpointUrl()).thenReturn(host);
+
+        int[] sizes = {10000, 20000, 30000};
+        for (int size : sizes){
+            String str = EventHandlerUtilsTest.makeRandomString(size);
+            byte[] compressed = EventHandlerUtils.compress(str);
+
+            when(mockEvent.getBody()).thenReturn(str);
+
+            Data data = EventWorker.getData(mockEvent);
+            assertEquals(data.getString("url"), host);
+            assertArrayEquals(data.getByteArray("bodyArray"), compressed);
+            assertNull(data.getString("body"));
+        }
+    }
+
+    @Test
+    public void getEventBodyFromInputData() throws Exception {
+        String orgStr = "any-string";
+        Data data = EventWorker.dataForEvent(host, orgStr);
+        when(eventWorker.getInputData()).thenReturn(data);
+
+        String str = eventWorker.getEventBodyFromInputData();
+        assertEquals(str, orgStr);
+    }
+
+    @Test
+    public void getEventBodyFromInputDataCompressed() {
+        String orgStr = "any-string";
+        Data data = EventWorker.dataForCompressedEvent(host, orgStr.getBytes());
+        when(eventWorker.getInputData()).thenReturn(data);
+
+        String str = eventWorker.getEventBodyFromInputData();
+        assertEquals(str, orgStr);
+    }
+
+    @Test
+    public void getEventBodyFromInputDataUncompressFailure() throws IOException {
+        PowerMockito.mockStatic(EventHandlerUtils.class);
+        PowerMockito.doThrow(new IOException()).when(EventHandlerUtils.class);
+        EventHandlerUtils.uncompress(any());  // PowerMockito throws exception on this static method
+
+        String orgStr = "any-string";
+        Data data = EventWorker.dataForCompressedEvent(host, orgStr.getBytes());
+        when(eventWorker.getInputData()).thenReturn(data);
+
+        String str = eventWorker.getEventBodyFromInputData();
+        assertNull(str);
+    }
+
+    @Test
+    public void doWork() {
+
+    }
+
+}

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventWorkerTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventWorkerTest.java
@@ -132,7 +132,7 @@ public class EventWorkerTest {
         LogEvent mockEvent = Mockito.mock(LogEvent.class);
         when(mockEvent.getEndpointUrl()).thenReturn(host);
 
-        int[] sizes = {10000, 100000, 1000000};
+        int[] sizes = {10000, 100000, 1000000, 3000000};
         for (int size : sizes){
             String str = EventHandlerUtilsTest.makeRandomString(size);
             String compressed = EventHandlerUtils.compress(str);

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventWorkerTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventWorkerTest.java
@@ -132,10 +132,11 @@ public class EventWorkerTest {
         LogEvent mockEvent = Mockito.mock(LogEvent.class);
         when(mockEvent.getEndpointUrl()).thenReturn(host);
 
-        int[] sizes = {10000, 20000, 30000};
+        int[] sizes = {10000, 100000, 1000000};
         for (int size : sizes){
             String str = EventHandlerUtilsTest.makeRandomString(size);
             String compressed = EventHandlerUtils.compress(str);
+            System.out.println("compressed: " + size + " -> " + compressed.length());
 
             when(mockEvent.getBody()).thenReturn(str);
 

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventWorkerTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventWorkerTest.java
@@ -132,7 +132,7 @@ public class EventWorkerTest {
         LogEvent mockEvent = Mockito.mock(LogEvent.class);
         when(mockEvent.getEndpointUrl()).thenReturn(host);
 
-        int[] sizes = {10000, 100000, 1000000, 3000000};
+        int[] sizes = {10000, 100000};
         for (int size : sizes){
             String str = EventHandlerUtilsTest.makeRandomString(size);
             String compressed = EventHandlerUtils.compress(str);

--- a/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventWorkerTest.java
+++ b/event-handler/src/test/java/com/optimizely/ab/android/event_handler/EventWorkerTest.java
@@ -76,22 +76,22 @@ public class EventWorkerTest {
 
     @Test
     public void dataForCompressedEvent() {
-        byte[] byteArray = "body-string".getBytes();
-        Data data = EventWorker.dataForCompressedEvent(host, byteArray);
+        String base64 = "abc123";
+        Data data = EventWorker.dataForCompressedEvent(host, base64);
         assertEquals(data.getString("url"), host);
-        assertArrayEquals(data.getByteArray("bodyCompressed"), byteArray);
+        assertEquals(data.getString("bodyCompressed"), base64);
         assertNull(data.getString("body"));
     }
 
     @Test
     public void compressEvent() throws IOException {
-        byte[] bytes = "any-string".getBytes();
+        String base64 = "abc123";
         PowerMockito.mockStatic(EventHandlerUtils.class);
-        when(EventHandlerUtils.compress(anyString())).thenReturn(bytes);
+        when(EventHandlerUtils.compress(anyString())).thenReturn(base64);
 
         Data data = EventWorker.compressEvent(host, smallBody);
         assertEquals(data.getString("url"), host);
-        assertArrayEquals(data.getByteArray("bodyCompressed"), bytes);
+        assertEquals(data.getString("bodyCompressed"), base64);
         assertNull(data.getString("body"));
     }
 
@@ -135,13 +135,13 @@ public class EventWorkerTest {
         int[] sizes = {10000, 20000, 30000};
         for (int size : sizes){
             String str = EventHandlerUtilsTest.makeRandomString(size);
-            byte[] compressed = EventHandlerUtils.compress(str);
+            String compressed = EventHandlerUtils.compress(str);
 
             when(mockEvent.getBody()).thenReturn(str);
 
             Data data = EventWorker.getData(mockEvent);
             assertEquals(data.getString("url"), host);
-            assertArrayEquals(data.getByteArray("bodyCompressed"), compressed);
+            assertEquals(data.getString("bodyCompressed"), compressed);
             assertNull(data.getString("body"));
         }
     }


### PR DESCRIPTION
## Summary
- WorkManager has 10KB limit on Data, so we cannot support batch events for a long list of attributes or large batch sizes.
- BatchEvents are compressed/decompressed to support large events.
- Compression/decompression is bypassed when the data size is less than the 10KB limit.

## Test plan
- Add tests for compress/decompress for a range of batch event sizes.
- Test for backward compatibility for old OS versions.

## Issues
- "OASIS-8000"