### PR TITLE
chore: clean up old settings in build.gradle

### DIFF
--- a/datafile-handler/build.gradle
+++ b/datafile-handler/build.gradle
@@ -51,8 +51,6 @@ dependencies {
     implementation "androidx.annotation:annotation:$annotations_ver"
     implementation "androidx.work:work-runtime:$work_runtime"
 
-    compileOnly "com.noveogroup.android:android-logger:$android_logger_ver"
-
     testImplementation "junit:junit:$junit_ver"
     testImplementation "org.mockito:mockito-core:$mockito_ver"
     testImplementation "com.noveogroup.android:android-logger:$android_logger_ver"

--- a/datafile-handler/src/main/res/values/strings.xml
+++ b/datafile-handler/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">datafile-handler</string>
-</resources>

--- a/event-handler/build.gradle
+++ b/event-handler/build.gradle
@@ -54,8 +54,6 @@ dependencies {
     // Base64
     implementation "commons-codec:commons-codec:1.15"
 
-    compileOnly "com.noveogroup.android:android-logger:$android_logger_ver"
-
     testImplementation "junit:junit:$junit_ver"
     testImplementation "org.mockito:mockito-core:$mockito_ver"
     testImplementation "org.powermock:powermock-mockito-release-full:$powermock_ver"

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -55,8 +55,6 @@ dependencies {
     implementation "com.google.code.gson:gson:$gson_ver"
     implementation "androidx.work:work-runtime:$work_runtime"
 
-    compileOnly "com.noveogroup.android:android-logger:$android_logger_ver"
-
     testImplementation "junit:junit:$junit_ver"
     testImplementation "org.mockito:mockito-core:$mockito_ver"
     testImplementation "com.noveogroup.android:android-logger:$android_logger_ver"

--- a/user-profile/build.gradle
+++ b/user-profile/build.gradle
@@ -51,8 +51,6 @@ dependencies {
 
     implementation "androidx.annotation:annotation:$annotations_ver"
 
-    compileOnly "com.noveogroup.android:android-logger:$android_logger_ver"
-
     testImplementation "junit:junit:$junit_ver"
     testImplementation "org.mockito:mockito-core:$mockito_ver"
     testImplementation "com.noveogroup.android:android-logger:$android_logger_ver"


### PR DESCRIPTION
## Summary
- clean up logger-related old settings in build.gradle