### PR TITLE
fix(datafileRescheduler): move config file read to a background thread

### DIFF
--- a/datafile-handler/src/androidTest/java/com/optimizely/ab/android/datafile_handler/DatafileReschedulerTest.java
+++ b/datafile-handler/src/androidTest/java/com/optimizely/ab/android/datafile_handler/DatafileReschedulerTest.java
@@ -119,18 +119,12 @@ public class DatafileReschedulerTest {
 
     @Test
     @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.N)
-    public void dispatchingOneWithoutEnvironment() {
+    public void dispatchingOneWithoutEnvironment() throws InterruptedException {
         // projectId: number string
         // sdkKey: alphabet string
         backgroundWatchersCache.setIsWatching(new DatafileConfig("1", null), true);
-
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
         dispatcher.dispatch();
-        try {
-            executor.awaitTermination(1, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            fail();
-        }
+        TimeUnit.SECONDS.sleep(1);
 
         verify(dispatcher).rescheduleService(captor.capture());
         assertEquals(new DatafileConfig("1", null), captor.getValue());
@@ -138,18 +132,12 @@ public class DatafileReschedulerTest {
 
     @Test
     @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.N)
-    public void dispatchingOneWithEnvironment() {
+    public void dispatchingOneWithEnvironment() throws InterruptedException {
         // projectId: number string
         // sdkKey: alphabet string
         backgroundWatchersCache.setIsWatching(new DatafileConfig(null, "A"), true);
-
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
         dispatcher.dispatch();
-        try {
-            executor.awaitTermination(1, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            fail();
-        }
+        TimeUnit.SECONDS.sleep(1);
 
         verify(dispatcher).rescheduleService(captor.capture());
         assertEquals(new DatafileConfig(null, "A"), captor.getValue());
@@ -157,19 +145,13 @@ public class DatafileReschedulerTest {
 
     @Test
     @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.N)
-    public void dispatchingManyForLegacy() {
+    public void dispatchingManyForLegacy() throws InterruptedException {
         backgroundWatchersCache.setIsWatching(new DatafileConfig("1", null), true);
         backgroundWatchersCache.setIsWatching(new DatafileConfig("2", "A"), true);
         backgroundWatchersCache.setIsWatching(new DatafileConfig(null, "B"), true);
         backgroundWatchersCache.setIsWatching(new DatafileConfig("3", null), true);
-
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
         dispatcher.dispatch();
-        try {
-            executor.awaitTermination(1, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            fail();
-        }
+        TimeUnit.SECONDS.sleep(1);
 
         verify(dispatcher, times(4)).rescheduleService(captor.capture());
         List array = new ArrayList<String>();
@@ -184,17 +166,11 @@ public class DatafileReschedulerTest {
 
     @Test
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.O)
-    public void dispatchingManyForJobScheduler() {
+    public void dispatchingManyForJobScheduler() throws InterruptedException {
         backgroundWatchersCache.setIsWatching(new DatafileConfig("1", null), true);
         backgroundWatchersCache.setIsWatching(new DatafileConfig(null, "A"), true);
-
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
         dispatcher.dispatch();
-        try {
-            executor.awaitTermination(1, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            fail();
-        }
+        TimeUnit.SECONDS.sleep(1);
 
         verify(dispatcher, never()).rescheduleService(captor.capture());
     }

--- a/datafile-handler/src/androidTest/java/com/optimizely/ab/android/datafile_handler/DatafileReschedulerTest.java
+++ b/datafile-handler/src/androidTest/java/com/optimizely/ab/android/datafile_handler/DatafileReschedulerTest.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016,2021-2022, Optimizely, Inc. and contributors              *
+ * Copyright 2016, 2021-2022, Optimizely, Inc. and contributors              *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileRescheduler.java
+++ b/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileRescheduler.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2021, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2022, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.optimizely.ab.android.shared.Cache;
 import com.optimizely.ab.android.shared.DatafileConfig;
@@ -76,6 +77,7 @@ public class DatafileRescheduler extends BroadcastReceiver {
      *
      * This abstraction mostly makes unit testing easier
      */
+    @VisibleForTesting
     public static class Dispatcher {
 
         @NonNull private final Context context;
@@ -111,6 +113,7 @@ public class DatafileRescheduler extends BroadcastReceiver {
             thread.start();
         }
 
+        @VisibleForTesting
         public void rescheduleService(DatafileConfig datafileConfig) {
             WorkerScheduler.scheduleService(context,
                     DatafileWorker.workerId + datafileConfig.getKey(),

--- a/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileRescheduler.java
+++ b/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileRescheduler.java
@@ -94,18 +94,18 @@ public class DatafileRescheduler extends BroadcastReceiver {
             Thread thread = new Thread() {
                 @Override
                 public void run() {
+                    // for scheduled jobs Android O and above, we use the JobScheduler and persistent periodic jobs
+                    // so, we don't need to do anything.
+                    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        logger.debug("Rescheduling datafile will be done by JobScheduler");
+                        return;
+                    }
+
                     // read config file in background thread
                     List<DatafileConfig> datafileConfigs = backgroundWatchersCache.getWatchingDatafileConfigs();
-
                     for (DatafileConfig datafileConfig : datafileConfigs) {
-                        // for scheduled jobs Android O and above, we use the JobScheduler and persistent periodic jobs
-                        // so, we don't need to do anything.
-                        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-                            rescheduleService(datafileConfig);
-                            logger.info("Rescheduled datafile watching for project {}", datafileConfig);
-                        } else {
-                            logger.debug("Rescheduling datafile will be done by JobScheduler");
-                        }
+                        rescheduleService(datafileConfig);
+                        logger.info("Rescheduled datafile watching for project {}", datafileConfig);
                     }
                 }
             };


### PR DESCRIPTION
## Summary
- Move config-file read to a background thread when DatafileRescheduler is invoked. 
  This will fix a potential source of ANRs.

## Test plan
- Add unit tests validating datafile worker scheduled properly from DatafileRescheduler.

## Issues
- OASIS-8128