### PR TITLE
chore: remove v from release tag check

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -123,7 +123,7 @@ jobs:
           disable-animations: true
           script: ./gradlew testAllModulesTravis
   publish:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/')
     uses: optimizely/android-sdk/.github/workflows/build.yml@master
     with:
       action: ship


### PR DESCRIPTION
## Summary
- publish is not trigger because "v" in tag checking