### PR TITLE
fix: call end inflater/deflater to avoid leaks

### DIFF
--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
@@ -1,23 +1,28 @@
+/****************************************************************************
+ * Copyright 2022, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
 package com.optimizely.ab.android.event_handler;
 
-import static java.util.zip.Deflater.BEST_COMPRESSION;
-
-import android.os.Build;
-
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
-import androidx.annotation.VisibleForTesting;
 
 import org.apache.commons.codec.binary.Base64;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.zip.Deflater;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 import java.util.zip.Inflater;
 
 public class EventHandlerUtils {

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventHandlerUtils.java
@@ -42,6 +42,9 @@ public class EventHandlerUtils {
             // encoded to Base64 (instead of byte[] since WorkManager.Data size is unexpectedly expanded with byte[]).
             return encodeToBase64(bytes);
         }
+        finally {
+            deflater.end();
+        }
     }
 
     public static String decompress(@NonNull String base64) throws Exception {
@@ -58,6 +61,9 @@ public class EventHandlerUtils {
             }
 
             return outputStream.toString();
+        }
+        finally {
+            inflater.end();
         }
     }
 


### PR DESCRIPTION
## Summary
- StrictMode detects leaks with inflater and deflater.
- Add end() calls at the end of inflate/deflate

## Test plan
- Pass with existing compress/decompress
- Test with StrictMode 

## Issues
- [ISSUE-419](https://github.com/optimizely/android-sdk/issues/419)