### PR TITLE
fix(DatafileClient): add timeouts to UrlConnections

### DIFF
--- a/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileClient.java
+++ b/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileClient.java
@@ -33,7 +33,9 @@ import java.net.URL;
  */
 public class DatafileClient {
     // easy way to set the connection timeout
-    public static int CONNECTION_TIMEOUT = 5 * 1000;
+    public static int CONNECTION_TIMEOUT = 10 * 1000;
+    public static int READ_TIMEOUT = 60 * 1000;
+
     // the numerical base for the exponential backoff
     public static final int REQUEST_BACKOFF_TIMEOUT = 2;
     // power the number of retries
@@ -81,8 +83,9 @@ public class DatafileClient {
                     }
 
                     client.setIfModifiedSince(urlConnection);
-
                     urlConnection.setConnectTimeout(CONNECTION_TIMEOUT);
+                    urlConnection.setReadTimeout(READ_TIMEOUT);
+
                     urlConnection.connect();
 
                     int status = urlConnection.getResponseCode();

--- a/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileClient.java
+++ b/datafile-handler/src/main/java/com/optimizely/ab/android/datafile_handler/DatafileClient.java
@@ -83,6 +83,7 @@ public class DatafileClient {
                     }
 
                     client.setIfModifiedSince(urlConnection);
+                    // set timeouts for releasing failed connections (default is 0 = no timeout).
                     urlConnection.setConnectTimeout(CONNECTION_TIMEOUT);
                     urlConnection.setReadTimeout(READ_TIMEOUT);
 

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventClient.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventClient.java
@@ -30,6 +30,10 @@ import java.net.HttpURLConnection;
  * Makes network requests related to events
  */
 class EventClient {
+    // easy way to set the connection timeout
+    public static int CONNECTION_TIMEOUT = 10 * 1000;
+    public static int READ_TIMEOUT = 60 * 1000;
+
     private final Client client;
     // Package private and non final so it can easily be mocked for tests
     private final Logger logger;
@@ -56,6 +60,9 @@ class EventClient {
                     if (urlConnection == null) {
                         return Boolean.FALSE;
                     }
+
+                    urlConnection.setConnectTimeout(CONNECTION_TIMEOUT);
+                    urlConnection.setReadTimeout(READ_TIMEOUT);
 
                     urlConnection.setRequestMethod("POST");
                     urlConnection.setRequestProperty("Content-Type", "application/json");

--- a/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventClient.java
+++ b/event-handler/src/main/java/com/optimizely/ab/android/event_handler/EventClient.java
@@ -61,6 +61,7 @@ class EventClient {
                         return Boolean.FALSE;
                     }
 
+                    // set timeouts for releasing failed connections (default is 0 = no timeout).
                     urlConnection.setConnectTimeout(CONNECTION_TIMEOUT);
                     urlConnection.setReadTimeout(READ_TIMEOUT);
 


### PR DESCRIPTION
## Summary
Set timeouts to UrlConnections for DatafileClient and EventClient so they can release resources when connection failed (0 by default, which is no timeout).

## Test plan
- Add unit tests for UrlConnections timeout

## Issues
- [OASIS-8568](https://jira.sso.episerver.net/browse/FSSDK-8568)
- https://github.com/optimizely/android-sdk/issues/429