### PR TITLE
Fix: Reverted putting namespace in gradle file instead of manifiest 

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -52,7 +52,6 @@ android {
     dexOptions {
         javaMaxHeapSize "4g"
     }
-    namespace 'com.optimizely.ab.android.sdk'
 }
 
 dependencies {

--- a/android-sdk/src/main/AndroidManifest.xml
+++ b/android-sdk/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
  ***************************************************************************/
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.optimizely.ab.android.sdk">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/datafile-handler/build.gradle
+++ b/datafile-handler/build.gradle
@@ -43,7 +43,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    namespace 'com.optimizely.ab.android.datafile_handler'
 }
 
 dependencies {

--- a/datafile-handler/src/main/AndroidManifest.xml
+++ b/datafile-handler/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
  ***************************************************************************/
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.optimizely.ab.android.datafile_handler">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <application>

--- a/event-handler/build.gradle
+++ b/event-handler/build.gradle
@@ -44,7 +44,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     buildToolsVersion build_tools_version
-    namespace 'com.optimizely.ab.android.event_handler'
 }
 
 dependencies {

--- a/event-handler/src/main/AndroidManifest.xml
+++ b/event-handler/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
  ***************************************************************************/
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.optimizely.ab.android.event_handler">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -44,7 +44,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     buildToolsVersion build_tools_version
-    namespace 'com.optimizely.ab.android.shared'
 }
 
 dependencies {

--- a/shared/src/main/AndroidManifest.xml
+++ b/shared/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
  ***************************************************************************/
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.optimizely.ab.android.shared">
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 </manifest>

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -36,7 +36,6 @@ android {
     lint {
         abortOnError false
     }
-    namespace 'com.optimizely.ab.android.test_app'
 }
 
 dependencies {

--- a/test-app/src/main/AndroidManifest.xml
+++ b/test-app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.optimizely.ab.android.test_app">
 
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/user-profile/build.gradle
+++ b/user-profile/build.gradle
@@ -43,7 +43,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    namespace 'com.optimizely.ab.android.user_profile'
 }
 
 dependencies {

--- a/user-profile/src/main/AndroidManifest.xml
+++ b/user-profile/src/main/AndroidManifest.xml
@@ -16,5 +16,6 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.optimizely.ab.android.user_profile"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
## Summary
- Reverted putting namespace in gradle file instead of manifiest (see PR 437)

## Issues
- FSSDK-8688