### PR TITLE
fix(ats): add proguard rule for ODPEvent

### DIFF
--- a/proguard-rules.txt
+++ b/proguard-rules.txt
@@ -24,6 +24,8 @@
 -keepclassmembers class  com.optimizely.ab.config.** {
     *;    
 }
+# Keep Payload classes that get sent to the ODP server
+-keep class com.optimizely.ab.odp.ODPEvent { *; }
 
 # Keep Payload classes that get sent to Optimizely's backend
 -keep class com.optimizely.ab.event.internal.payload.** { *; }

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -17,6 +17,12 @@ android {
         unitTests.returnDefaultValues = true
     }
     buildTypes {
+        debug {
+            // enable proguard for debug mode (keep both of these to detect issues while testing)
+            minifyEnabled true
+            debuggable false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.kt
+++ b/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.kt
@@ -19,7 +19,6 @@ import android.app.Application
 import android.content.Context
 import android.os.Build
 import com.optimizely.ab.android.sdk.OptimizelyManager
-import com.optimizely.ab.android.test_app.Samples.APISamplesInJava
 import java.util.*
 import java.util.concurrent.TimeUnit
 

--- a/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.kt
+++ b/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.kt
@@ -19,6 +19,7 @@ import android.app.Application
 import android.content.Context
 import android.os.Build
 import com.optimizely.ab.android.sdk.OptimizelyManager
+import com.optimizely.ab.android.test_app.Samples.APISamplesInJava
 import java.util.*
 import java.util.concurrent.TimeUnit
 

--- a/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.kt
+++ b/test-app/src/main/java/com/optimizely/ab/android/test_app/MyApplication.kt
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2021, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2021, 2023 Optimizely, Inc. and contributors              *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/test-app/src/main/java/com/optimizely/ab/android/test_app/Samples/APISamplesInJava.java
+++ b/test-app/src/main/java/com/optimizely/ab/android/test_app/Samples/APISamplesInJava.java
@@ -90,8 +90,8 @@ public class APISamplesInJava {
         samplesForDoc_NotificatonListener(context);
         samplesForDoc_OlderVersions(context);
         samplesForDoc_ForcedDecision(context);
+        samplesForDoc_ODP(context);
     }
-
 
     static public void samplesForDecide(Context context) {
         // this default-options will be applied to all following decide calls.
@@ -857,6 +857,18 @@ public class APISamplesInJava {
         // remove forced variations
         success = user.removeForcedDecision(flagAndABTestContext);
         success = user.removeAllForcedDecisions();
+    }
+
+    static public void samplesForDoc_ODP(Context context) {
+        OptimizelyManager optimizelyManager = OptimizelyManager.builder().withSDKKey("VivZyCGPHY369D4z8T9yG").build(context);
+        optimizelyManager.initialize(context, null, (OptimizelyClient client) -> {
+            OptimizelyUserContext userContext = client.createUserContext("user_123");
+            userContext.fetchQualifiedSegments((status) -> {
+                Log.d("Optimizely", "[ODP] segments = " + userContext.getQualifiedSegments());
+                OptimizelyDecision optDecision = userContext.decide("odp-flag-1");
+                Log.d("Optimizely", "[ODP] decision = " + optDecision.toString());
+            });
+        });
     }
 
 }

--- a/test-app/src/main/java/com/optimizely/ab/android/test_app/Samples/APISamplesInJava.java
+++ b/test-app/src/main/java/com/optimizely/ab/android/test_app/Samples/APISamplesInJava.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2020, 2022, Optimizely, Inc. and contributors                  *
+ * Copyright 2020, 2022-2023, Optimizely, Inc. and contributors             *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/test-app/src/main/java/com/optimizely/ab/android/test_app/Samples/APISamplesInKotlin.kt
+++ b/test-app/src/main/java/com/optimizely/ab/android/test_app/Samples/APISamplesInKotlin.kt
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2022, Optimizely, Inc. and contributors                        *
+ * Copyright 2022-2023, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -76,6 +76,7 @@ object APISamplesInKotlin {
         samplesForDoc_NotificatonListener(context)
         samplesForDoc_OlderVersions(context)
         samplesForDoc_ForcedDecision(context)
+        samplesForDoc_ODP(context)
     }
 
     fun samplesForDecide(context: Context) {
@@ -826,6 +827,19 @@ object APISamplesInKotlin {
         // remove forced variations
         success = user.removeForcedDecision(flagAndABTestContext)
         success = user.removeAllForcedDecisions()
+    }
+
+    fun samplesForDoc_ODP(context: Context?) {
+        val optimizelyManager =
+            OptimizelyManager.builder().withSDKKey("VivZyCGPHY369D4z8T9yG").build(context)
+        optimizelyManager.initialize(context!!, null) { client: OptimizelyClient ->
+            val userContext = client.createUserContext("user_123")
+            userContext!!.fetchQualifiedSegments { status: Boolean? ->
+                Log.d("Optimizely", "[ODP] segments = " + userContext.qualifiedSegments)
+                val optDecision = userContext.decide("odp-flag-1")
+                Log.d("Optimizely", "[ODP] decision = $optDecision")
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
Add a proguard rule to keep ODPEvent.
Add sample codes for ODP.

## Issues
- FSSDK-123