### PR TITLE
[FSSDK-9432] fix: fix to support arbitrary client names to be included in logx and odp events.

### DIFF
--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/ODPIntegrationUpdateConfigTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/ODPIntegrationUpdateConfigTest.java
@@ -117,7 +117,9 @@ public class ODPIntegrationUpdateConfigTest {
             notificationCenter,
             null,
             odpManager,
-            "test-vuid");
+            "test-vuid",
+            null,
+            null);
     }
 
     @Test

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyClientEngineTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyClientEngineTest.java
@@ -35,20 +35,20 @@ import static org.mockito.Mockito.when;
 @RunWith(AndroidJUnit4.class)
 public class OptimizelyClientEngineTest {
     @Test
-    public void testGetClientEngineFromContextAndroidTV() {
+    public void testGetClientEngineNameFromContextAndroidTV() {
         Context context = mock(Context.class);
         UiModeManager uiModeManager = mock(UiModeManager.class);
         when(context.getSystemService(Context.UI_MODE_SERVICE)).thenReturn(uiModeManager);
         when(uiModeManager.getCurrentModeType()).thenReturn(Configuration.UI_MODE_TYPE_TELEVISION);
-        assertEquals(EventBatch.ClientEngine.ANDROID_TV_SDK, OptimizelyClientEngine.getClientEngineFromContext(context));
+        assertEquals("android-tv-sdk", OptimizelyClientEngine.getClientEngineNameFromContext(context));
     }
 
     @Test
-    public void testGetClientEngineFromContextAndroid() {
+    public void testGetClientEngineNameFromContextAndroid() {
         Context context = mock(Context.class);
         UiModeManager uiModeManager = mock(UiModeManager.class);
         when(context.getSystemService(Context.UI_MODE_SERVICE)).thenReturn(uiModeManager);
         when(uiModeManager.getCurrentModeType()).thenReturn(Configuration.UI_MODE_TYPE_NORMAL);
-        assertEquals(EventBatch.ClientEngine.ANDROID_SDK, OptimizelyClientEngine.getClientEngineFromContext(context));
+        assertEquals("android-sdk", OptimizelyClientEngine.getClientEngineNameFromContext(context));
     }
 }

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerEventHandlerTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerEventHandlerTest.java
@@ -65,4 +65,25 @@ public class OptimizelyManagerEventHandlerTest {
         assertEquals(argument.getValue().getEventBatch().getClientVersion(), BuildConfig.CLIENT_VERSION);
     }
 
+    @Test
+    public void eventClientWithCustomNameAndVersion() throws Exception {
+        EventHandler mockEventHandler = mock(EventHandler.class);
+
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        OptimizelyManager optimizelyManager = OptimizelyManager.builder()
+            .withSDKKey("any-sdk-key")
+            .withEventDispatchInterval(0, TimeUnit.SECONDS)
+            .withEventHandler(mockEventHandler)
+            .withClientInfo("test-sdk", "test-version")
+            .build(context);
+
+        OptimizelyClient optimizelyClient = optimizelyManager.initialize(context, minDatafileWithEvent);
+        optimizelyClient.track("test_event", "tester");
+
+        ArgumentCaptor<LogEvent> argument = ArgumentCaptor.forClass(LogEvent.class);
+        verify(mockEventHandler, timeout(5000)).dispatchEvent(argument.capture());
+        assertEquals(argument.getValue().getEventBatch().getClientName(), "android-sdk");
+        assertEquals(argument.getValue().getEventBatch().getClientVersion(), BuildConfig.CLIENT_VERSION);
+    }
+
 }

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerEventHandlerTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerEventHandlerTest.java
@@ -82,8 +82,8 @@ public class OptimizelyManagerEventHandlerTest {
 
         ArgumentCaptor<LogEvent> argument = ArgumentCaptor.forClass(LogEvent.class);
         verify(mockEventHandler, timeout(5000)).dispatchEvent(argument.capture());
-        assertEquals(argument.getValue().getEventBatch().getClientName(), "android-sdk");
-        assertEquals(argument.getValue().getEventBatch().getClientVersion(), BuildConfig.CLIENT_VERSION);
+        assertEquals(argument.getValue().getEventBatch().getClientName(), "test-sdk");
+        assertEquals(argument.getValue().getEventBatch().getClientVersion(), "test-version");
     }
 
 }

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerTest.java
@@ -163,7 +163,7 @@ public class OptimizelyManagerTest {
         EventHandler eventHandler = mock(DefaultEventHandler.class);
         EventProcessor eventProcessor = mock(EventProcessor.class);
         OptimizelyManager optimizelyManager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, 3600L, datafileHandler, null, 3600L,
-                eventHandler, eventProcessor, null, null, null, null, null);
+                eventHandler, eventProcessor, null, null, null, null, null, null, null);
         /*
          * Scenario#1: when datafile is not Empty
          * Scenario#2: when datafile is Empty
@@ -222,7 +222,7 @@ public class OptimizelyManagerTest {
         EventHandler eventHandler = mock(DefaultEventHandler.class);
         EventProcessor eventProcessor = mock(EventProcessor.class);
         final OptimizelyManager optimizelyManager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, 3600L, datafileHandler, null, 3600L,
-                eventHandler, eventProcessor, null, null, null, null, null);
+                eventHandler, eventProcessor, null, null, null, null, null, null, null);
 
         /*
          * Scenario#1: when datafile is not Empty
@@ -494,7 +494,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -527,7 +527,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -560,7 +560,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -593,7 +593,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null);
 
         doAnswer(
                 (Answer<Object>) invocation -> {
@@ -625,7 +625,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -658,7 +658,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -692,7 +692,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -725,7 +725,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = spy(new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null));
+                null, null, null, null, null, null, null, null, null));
 
         datafileHandler.removeSavedDatafile(context, manager.getDatafileConfig());
         OptimizelyClient client = manager.initialize(context, R.raw.datafile, downloadToCache, updateConfigOnNewDatafile);
@@ -742,7 +742,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = spy(new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null));
+                null, null, null, null, null, null, null, null, null));
 
         datafileHandler.removeSavedDatafile(context, manager.getDatafileConfig());
         OptimizelyClient client = manager.initialize(context, R.raw.datafile);

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyClientEngine.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyClientEngine.java
@@ -29,11 +29,29 @@ import com.optimizely.ab.event.internal.payload.EventBatch;
 public class OptimizelyClientEngine {
 
     /**
+     * Get client engine name for current UI mode type
+     *
+     * @param context any valid Android {@link Context}
+     * @return client engine name ("android-sdk" or "android-tv-sdk")
+     */
+    public static String getClientEngineNameFromContext(@NonNull Context context) {
+        UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
+
+        if (uiModeManager != null && uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return "android-tv-sdk";
+        }
+
+        return "android-sdk";
+    }
+
+    /**
      * Get client engine value for current UI mode type
      *
      * @param context any valid Android {@link Context}
      * @return String value of client engine
+     * @deprecated Consider using {@link #getClientEngineNameFromContext(Context, Integer, OptimizelyStartListener)}
      */
+    @Deprecated
     public static EventBatch.ClientEngine getClientEngineFromContext(@NonNull Context context) {
         UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
 

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -99,7 +99,8 @@ public class OptimizelyManager {
     @Nullable private OptimizelyStartListener optimizelyStartListener;
 
     @Nullable private final List<OptimizelyDecideOption> defaultDecideOptions;
-    private String sdkVersion = null;
+    private String customSdkName = null;
+    private String customSdkVersion = null;
 
     OptimizelyManager(@Nullable String projectId,
                       @Nullable String sdkKey,
@@ -115,7 +116,9 @@ public class OptimizelyManager {
                       @NonNull NotificationCenter notificationCenter,
                       @Nullable List<OptimizelyDecideOption> defaultDecideOptions,
                       @Nullable ODPManager odpManager,
-                      @Nullable String vuid) {
+                      @Nullable String vuid,
+                      @Nullable String clientEngineName,
+                      @Nullable String clientVersion) {
 
         if (projectId == null && sdkKey == null) {
             logger.error("projectId and sdkKey are both null!");
@@ -141,12 +144,8 @@ public class OptimizelyManager {
         this.notificationCenter = notificationCenter;
         this.defaultDecideOptions = defaultDecideOptions;
 
-        try {
-            sdkVersion = BuildConfig.CLIENT_VERSION;
-            logger.info("SDK Version: {}", sdkVersion);
-        } catch (Exception e) {
-            logger.warn("Error getting BuildConfig version");
-        }
+        this.customSdkName = clientEngineName;
+        this.customSdkVersion = clientVersion;
     }
 
     @VisibleForTesting
@@ -514,6 +513,29 @@ public class OptimizelyManager {
         return datafileHandler;
     }
 
+    @NonNull
+    public String getSdkName(Context context) {
+        String sdkName = customSdkName;
+        if (sdkName == null) {
+            sdkName = OptimizelyClientEngine.getClientEngineNameFromContext(context);
+        }
+        return sdkName
+    }
+
+    @NonNull
+    public String getSdkVersion() {
+        String sdkVersion = customSdkVersion;
+        if (sdkVersion == null) {
+            try {
+                sdkVersion = BuildConfig.CLIENT_VERSION;
+            } catch (Exception e) {
+                logger.warn("Error getting BuildConfig version");
+                sdkVersion = "UNKNOWN";
+            }
+        }
+        return sdkVersion
+    }
+
     private boolean datafileDownloadEnabled() {
         return datafileDownloadInterval > 0;
     }
@@ -577,7 +599,8 @@ public class OptimizelyManager {
     private OptimizelyClient buildOptimizely(@NonNull Context context, @NonNull String datafile) throws ConfigParseException {
         EventHandler eventHandler = getEventHandler(context);
 
-        EventBatch.ClientEngine clientEngine = OptimizelyClientEngine.getClientEngineFromContext(context);
+        String sdkName = getSdkName();
+        String sdkVersion = getSdkVersion();
 
         Optimizely.Builder builder = Optimizely.builder();
 
@@ -594,7 +617,8 @@ public class OptimizelyManager {
         }
 
         // override client sdk name/version to be included in events
-        builder.withClientInfo(clientEngine, sdkVersion);
+        builder.withClientInfo(sdkName, sdkVersion);
+        logger.info("SDK name: {} and version: {}", sdkName, sdkVersion);
 
         if (errorHandler != null) {
             builder.withErrorHandler(errorHandler);
@@ -746,6 +770,9 @@ public class OptimizelyManager {
         private int timeoutForODPEventDispatchInSecs = 10;
         private boolean odpEnabled = true;
         private String vuid = null;
+
+        private String customSdkName = null;
+        private String customSdkVersion = null;
 
         @Deprecated
         /**
@@ -992,6 +1019,18 @@ public class OptimizelyManager {
         }
 
         /**
+         * Override the SDK name and version (for client SDKs like flutter-sdk wrapping the core android-sdk) to be included in events.
+         *
+         * @param clientEngineName the client engine name ("flutter/android-sdk", etc.).
+         * @param clientVersion the client SDK version.
+         * @return this {@link Builder} instance
+         */
+        public Builder withClientInfo(@Nullable String clientEngineName, @Nullable String clientVersion) {
+            this.customSdkName = clientEngineName;
+            this.customSdkVersion = clientVersion;
+            return this;
+        }
+        /**
          * Get a new {@link Builder} instance to create {@link OptimizelyManager} with.
          * @param  context the application context used to create default service if not provided.
          * @return a {@link Builder} instance
@@ -1103,7 +1142,10 @@ public class OptimizelyManager {
                     notificationCenter,
                     defaultDecideOptions,
                     odpManager,
-                    vuid);
+                    vuid,
+                    customSdkName,
+                    customSdkVersion
+            );
         }
     }
 }

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -519,7 +519,7 @@ public class OptimizelyManager {
         if (sdkName == null) {
             sdkName = OptimizelyClientEngine.getClientEngineNameFromContext(context);
         }
-        return sdkName
+        return sdkName;
     }
 
     @NonNull
@@ -533,7 +533,7 @@ public class OptimizelyManager {
                 sdkVersion = "UNKNOWN";
             }
         }
-        return sdkVersion
+        return sdkVersion;
     }
 
     private boolean datafileDownloadEnabled() {
@@ -599,7 +599,7 @@ public class OptimizelyManager {
     private OptimizelyClient buildOptimizely(@NonNull Context context, @NonNull String datafile) throws ConfigParseException {
         EventHandler eventHandler = getEventHandler(context);
 
-        String sdkName = getSdkName();
+        String sdkName = getSdkName(context);
         String sdkVersion = getSdkVersion();
 
         Optimizely.Builder builder = Optimizely.builder();

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
@@ -216,18 +216,13 @@ public class OptimizelyManagerBuilderTest {
     }
 
     @Test
-    public void testBuildWithDatafileDownloadInterval_workerCancelledWhenNoIntervalProvided() throws Exception {
+    public void testBuildWithCustomSdkNameAndVersion() throws Exception {
         OptimizelyManager manager = OptimizelyManager.builder()
-                .withSDKKey(testSdkKey)
-                .withDatafileHandler(mockDatafileHandler)
-                .withVuid("any-to-avoid-generate")
-                .build(mockContext);
-        OptimizelyManager spyManager = spy(manager);
-        when(spyManager.isAndroidVersionSupported()).thenReturn(true);
-        spyManager.initialize(mockContext, "");
-
-        verify(mockDatafileHandler).stopBackgroundUpdates(any(), any());
-        verify(mockDatafileHandler, never()).startBackgroundUpdates(any(), any(), any(), any());
+            .withSDKKey(testSdkKey)
+            .withClientInfo("test-sdk", "test-version")
+            .build(mockContext);
+        assertEquals(manager.getSdkName(mockContext), "test-sdk");
+        assertEquals(manager.getSdkVersion(), "test-version");
     }
 
     @Test

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
@@ -220,6 +220,7 @@ public class OptimizelyManagerBuilderTest {
         OptimizelyManager manager = OptimizelyManager.builder()
             .withSDKKey(testSdkKey)
             .withClientInfo("test-sdk", "test-version")
+            .withVuid("any-to-avoid-generate")
             .build(mockContext);
         assertEquals(manager.getSdkName(mockContext), "test-sdk");
         assertEquals(manager.getSdkVersion(), "test-version");
@@ -249,7 +250,9 @@ public class OptimizelyManagerBuilderTest {
             any(NotificationCenter.class),
             any(),                         // nullable (DefaultDecideOptions)
             any(ODPManager.class),
-            eq("test-vuid"));
+            eq("test-vuid"),
+            any(),
+            any());
     }
 
     @Test
@@ -277,7 +280,9 @@ public class OptimizelyManagerBuilderTest {
             any(NotificationCenter.class),
             any(),                         // nullable (DefaultDecideOptions)
             isNull(),
-            eq("test-vuid"));
+            eq("test-vuid"),
+            any(),
+            any());
     }
 
     @Test

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerIntervalTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerIntervalTest.java
@@ -104,7 +104,9 @@ public class OptimizelyManagerIntervalTest {
                 any(NotificationCenter.class),
                 any(),                         // nullable (DefaultDecideOptions)
                 any(ODPManager.class),
-                anyString());
+                anyString(),
+                any(),
+                any());
     }
 
     @Test
@@ -131,7 +133,9 @@ public class OptimizelyManagerIntervalTest {
                 any(NotificationCenter.class),
                 any(),                         // nullable (DefaultDecideOptions)
                 any(ODPManager.class),
-                anyString());
+                anyString(),
+                any(),
+                any());
     }
 
     @Test
@@ -170,7 +174,9 @@ public class OptimizelyManagerIntervalTest {
                 any(NotificationCenter.class),
                 any(),                         // nullable (DefaultDecideOptions)
                 any(ODPManager.class),
-                anyString());
+                anyString(),
+                any(),
+                any());
     }
 
     @Test
@@ -212,7 +218,9 @@ public class OptimizelyManagerIntervalTest {
                 any(NotificationCenter.class),
                 any(),                         // nullable (DefaultDecideOptions)
                 any(ODPManager.class),
-                anyString());
+                anyString(),
+                any(),
+                any());
     }
 
     @Test
@@ -250,7 +258,9 @@ public class OptimizelyManagerIntervalTest {
                 any(NotificationCenter.class),
                 any(),                         // nullable (DefaultDecideOptions)
                 any(ODPManager.class),
-                anyString());
+                anyString(),
+                any(),
+                any());
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ allprojects {
         mavenCentral()
         // SNAPSHOT support
         maven {url "https://oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url "https://jitpack.io" }
     }
 
     configurations.all {

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     api ("com.optimizely.ab:core-api:$java_core_ver") {
         exclude group: 'com.google.code.findbugs'
     }
+
     implementation "androidx.annotation:annotation:$annotations_ver"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.work:work-runtime:$work_runtime"


### PR DESCRIPTION
## Summary
Fix to support arbitrary client names to be included in logx and odp events.
This fix depends on the change in the java-sdk core (https://github.com/optimizely/java-sdk/pull/524)

## Test plan
Add unit tests for new APIs.
Pass all existing tests.

## Issues
- FSSDK-9432