### PR TITLE
[FSSDK-9406] fix: Added catch block to capture resource not found exception

### DIFF
--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -364,7 +364,7 @@ public class OptimizelyManager {
                 }
             }
             return safeLoadResource(context, datafileRes);
-        } catch (NullPointerException e){
+        } catch (NullPointerException | Resources.NotFoundException e){
             logger.error("Unable to find compiled data file in raw resource",e);
         }
         return null;


### PR DESCRIPTION
## Summary
- This will gracefully log the exception that was reported in issue #458 

## Test plan
All tests should pass
## Issues
- [FSSDK-9406](https://jira.sso.episerver.net/browse/FSSDK-9406)