### PR TITLE
[FSSDK-9432] fix: fix to support arbitrary client names to be included in logx and odp events.

### DIFF
--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/ODPIntegrationUpdateConfigTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/ODPIntegrationUpdateConfigTest.java
@@ -117,9 +117,7 @@ public class ODPIntegrationUpdateConfigTest {
             notificationCenter,
             null,
             odpManager,
-            "test-vuid",
-            null,
-            null);
+            "test-vuid");
     }
 
     @Test

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyClientEngineTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyClientEngineTest.java
@@ -35,20 +35,20 @@ import static org.mockito.Mockito.when;
 @RunWith(AndroidJUnit4.class)
 public class OptimizelyClientEngineTest {
     @Test
-    public void testGetClientEngineNameFromContextAndroidTV() {
+    public void testGetClientEngineFromContextAndroidTV() {
         Context context = mock(Context.class);
         UiModeManager uiModeManager = mock(UiModeManager.class);
         when(context.getSystemService(Context.UI_MODE_SERVICE)).thenReturn(uiModeManager);
         when(uiModeManager.getCurrentModeType()).thenReturn(Configuration.UI_MODE_TYPE_TELEVISION);
-        assertEquals("android-tv-sdk", OptimizelyClientEngine.getClientEngineNameFromContext(context));
+        assertEquals(EventBatch.ClientEngine.ANDROID_TV_SDK, OptimizelyClientEngine.getClientEngineFromContext(context));
     }
 
     @Test
-    public void testGetClientEngineNameFromContextAndroid() {
+    public void testGetClientEngineFromContextAndroid() {
         Context context = mock(Context.class);
         UiModeManager uiModeManager = mock(UiModeManager.class);
         when(context.getSystemService(Context.UI_MODE_SERVICE)).thenReturn(uiModeManager);
         when(uiModeManager.getCurrentModeType()).thenReturn(Configuration.UI_MODE_TYPE_NORMAL);
-        assertEquals("android-sdk", OptimizelyClientEngine.getClientEngineNameFromContext(context));
+        assertEquals(EventBatch.ClientEngine.ANDROID_SDK, OptimizelyClientEngine.getClientEngineFromContext(context));
     }
 }

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerEventHandlerTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerEventHandlerTest.java
@@ -65,25 +65,4 @@ public class OptimizelyManagerEventHandlerTest {
         assertEquals(argument.getValue().getEventBatch().getClientVersion(), BuildConfig.CLIENT_VERSION);
     }
 
-    @Test
-    public void eventClientWithCustomNameAndVersion() throws Exception {
-        EventHandler mockEventHandler = mock(EventHandler.class);
-
-        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        OptimizelyManager optimizelyManager = OptimizelyManager.builder()
-            .withSDKKey("any-sdk-key")
-            .withEventDispatchInterval(0, TimeUnit.SECONDS)
-            .withEventHandler(mockEventHandler)
-            .withClientInfo("test-sdk", "test-version")
-            .build(context);
-
-        OptimizelyClient optimizelyClient = optimizelyManager.initialize(context, minDatafileWithEvent);
-        optimizelyClient.track("test_event", "tester");
-
-        ArgumentCaptor<LogEvent> argument = ArgumentCaptor.forClass(LogEvent.class);
-        verify(mockEventHandler, timeout(5000)).dispatchEvent(argument.capture());
-        assertEquals(argument.getValue().getEventBatch().getClientName(), "test-sdk");
-        assertEquals(argument.getValue().getEventBatch().getClientVersion(), "test-version");
-    }
-
 }

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerTest.java
@@ -163,7 +163,7 @@ public class OptimizelyManagerTest {
         EventHandler eventHandler = mock(DefaultEventHandler.class);
         EventProcessor eventProcessor = mock(EventProcessor.class);
         OptimizelyManager optimizelyManager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, 3600L, datafileHandler, null, 3600L,
-                eventHandler, eventProcessor, null, null, null, null, null, null, null);
+                eventHandler, eventProcessor, null, null, null, null, null);
         /*
          * Scenario#1: when datafile is not Empty
          * Scenario#2: when datafile is Empty
@@ -222,7 +222,7 @@ public class OptimizelyManagerTest {
         EventHandler eventHandler = mock(DefaultEventHandler.class);
         EventProcessor eventProcessor = mock(EventProcessor.class);
         final OptimizelyManager optimizelyManager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, 3600L, datafileHandler, null, 3600L,
-                eventHandler, eventProcessor, null, null, null, null, null, null, null);
+                eventHandler, eventProcessor, null, null, null, null, null);
 
         /*
          * Scenario#1: when datafile is not Empty
@@ -494,7 +494,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -527,7 +527,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -560,7 +560,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -593,7 +593,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
 
         doAnswer(
                 (Answer<Object>) invocation -> {
@@ -625,7 +625,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -658,7 +658,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -692,7 +692,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -725,7 +725,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = spy(new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null));
+                null, null, null, null, null, null, null));
 
         datafileHandler.removeSavedDatafile(context, manager.getDatafileConfig());
         OptimizelyClient client = manager.initialize(context, R.raw.datafile, downloadToCache, updateConfigOnNewDatafile);
@@ -742,7 +742,7 @@ public class OptimizelyManagerTest {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         OptimizelyManager manager = spy(new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null));
+                null, null, null, null, null, null, null));
 
         datafileHandler.removeSavedDatafile(context, manager.getDatafileConfig());
         OptimizelyClient client = manager.initialize(context, R.raw.datafile);

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyClientEngine.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyClientEngine.java
@@ -29,29 +29,11 @@ import com.optimizely.ab.event.internal.payload.EventBatch;
 public class OptimizelyClientEngine {
 
     /**
-     * Get client engine name for current UI mode type
-     *
-     * @param context any valid Android {@link Context}
-     * @return client engine name ("android-sdk" or "android-tv-sdk")
-     */
-    public static String getClientEngineNameFromContext(@NonNull Context context) {
-        UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
-
-        if (uiModeManager != null && uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
-            return "android-tv-sdk";
-        }
-
-        return "android-sdk";
-    }
-
-    /**
      * Get client engine value for current UI mode type
      *
      * @param context any valid Android {@link Context}
      * @return String value of client engine
-     * @deprecated Consider using {@link #getClientEngineNameFromContext(Context, Integer, OptimizelyStartListener)}
      */
-    @Deprecated
     public static EventBatch.ClientEngine getClientEngineFromContext(@NonNull Context context) {
         UiModeManager uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
 

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
@@ -216,14 +216,18 @@ public class OptimizelyManagerBuilderTest {
     }
 
     @Test
-    public void testBuildWithCustomSdkNameAndVersion() throws Exception {
+    public void testBuildWithDatafileDownloadInterval_workerCancelledWhenNoIntervalProvided() throws Exception {
         OptimizelyManager manager = OptimizelyManager.builder()
-            .withSDKKey(testSdkKey)
-            .withClientInfo("test-sdk", "test-version")
-            .withVuid("any-to-avoid-generate")
-            .build(mockContext);
-        assertEquals(manager.getSdkName(mockContext), "test-sdk");
-        assertEquals(manager.getSdkVersion(), "test-version");
+                .withSDKKey(testSdkKey)
+                .withDatafileHandler(mockDatafileHandler)
+                .withVuid("any-to-avoid-generate")
+                .build(mockContext);
+        OptimizelyManager spyManager = spy(manager);
+        when(spyManager.isAndroidVersionSupported()).thenReturn(true);
+        spyManager.initialize(mockContext, "");
+
+        verify(mockDatafileHandler).stopBackgroundUpdates(any(), any());
+        verify(mockDatafileHandler, never()).startBackgroundUpdates(any(), any(), any(), any());
     }
 
     @Test
@@ -250,9 +254,7 @@ public class OptimizelyManagerBuilderTest {
             any(NotificationCenter.class),
             any(),                         // nullable (DefaultDecideOptions)
             any(ODPManager.class),
-            eq("test-vuid"),
-            any(),
-            any());
+            eq("test-vuid"));
     }
 
     @Test
@@ -280,9 +282,7 @@ public class OptimizelyManagerBuilderTest {
             any(NotificationCenter.class),
             any(),                         // nullable (DefaultDecideOptions)
             isNull(),
-            eq("test-vuid"),
-            any(),
-            any());
+            eq("test-vuid"));
     }
 
     @Test

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerIntervalTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerIntervalTest.java
@@ -104,9 +104,7 @@ public class OptimizelyManagerIntervalTest {
                 any(NotificationCenter.class),
                 any(),                         // nullable (DefaultDecideOptions)
                 any(ODPManager.class),
-                anyString(),
-                any(),
-                any());
+                anyString());
     }
 
     @Test
@@ -133,9 +131,7 @@ public class OptimizelyManagerIntervalTest {
                 any(NotificationCenter.class),
                 any(),                         // nullable (DefaultDecideOptions)
                 any(ODPManager.class),
-                anyString(),
-                any(),
-                any());
+                anyString());
     }
 
     @Test
@@ -174,9 +170,7 @@ public class OptimizelyManagerIntervalTest {
                 any(NotificationCenter.class),
                 any(),                         // nullable (DefaultDecideOptions)
                 any(ODPManager.class),
-                anyString(),
-                any(),
-                any());
+                anyString());
     }
 
     @Test
@@ -218,9 +212,7 @@ public class OptimizelyManagerIntervalTest {
                 any(NotificationCenter.class),
                 any(),                         // nullable (DefaultDecideOptions)
                 any(ODPManager.class),
-                anyString(),
-                any(),
-                any());
+                anyString());
     }
 
     @Test
@@ -258,9 +250,7 @@ public class OptimizelyManagerIntervalTest {
                 any(NotificationCenter.class),
                 any(),                         // nullable (DefaultDecideOptions)
                 any(ODPManager.class),
-                anyString(),
-                any(),
-                any());
+                anyString());
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ allprojects {
         mavenCentral()
         // SNAPSHOT support
         maven {url "https://oss.sonatype.org/content/repositories/snapshots/" }
-        maven { url "https://jitpack.io" }
     }
 
     configurations.all {

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -51,7 +51,6 @@ dependencies {
     api ("com.optimizely.ab:core-api:$java_core_ver") {
         exclude group: 'com.google.code.findbugs'
     }
-
     implementation "androidx.annotation:annotation:$annotations_ver"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.work:work-runtime:$work_runtime"


### PR DESCRIPTION
## Summary
Fix to support arbitrary client names to be included in logx and odp events.
This fix depends on the change in the java-sdk core (https://github.com/optimizely/java-sdk/pull/524)

## Test plan
Add unit tests for new APIs.
Pass all existing tests.

## Issues
- FSSDK-9432