### PR TITLE
[FSSDK-10230] fix: GitHub slug `head_ref` vulnerability resolved

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,9 +41,11 @@ jobs:
       
     - name: set SDK Branch if PR
       if: ${{ github.event_name == 'pull_request' }}
+      env:
+        HEAD_REF: ${{ github.head_ref }}
       run: |
-        echo "SDK_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
-        echo "TRAVIS_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
+        echo "SDK_BRANCH=${{ HEAD_REF }}" >> $GITHUB_ENV
+        echo "TRAVIS_BRANCH=${{ HEAD_REF }}" >> $GITHUB_ENV
     - name: set SDK Branch if not pull request
       if: ${{ github.event_name != 'pull_request' }}
       run: |


### PR DESCRIPTION
## Summary
- Assigned the value of `github.head_ref` to an intermediate environment variable and employ that variable in the shell script.

### Reference:
- https://securitylab.github.com/research/github-actions-untrusted-input/
- https://codeql.github.com/codeql-query-help/javascript/js-actions-command-injection/
- https://securitylab.github.com/advisories/GHSL-2023-110_Wing_Language/


## Test plan
- N / A

## Issues
- [FSSDK-10230](https://jira.sso.episerver.net/browse/FSSDK-10230)