### PR TITLE
[FSSDK-10674] chore: prepare for release 4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Optimizely Android X SDK Changelog
 
 
+## 4.0.4
+September 10th, 2024
+
+### Bug Fixes
+* R8 configuration breaks Gson use at runtime ([#493](https://github.com/optimizely/android-sdk/pull/493)).
+
+
 ## 4.0.0
 January 17th, 2024
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.optimizely.ab:android-sdk:4.0.0'
+	implementation 'com.optimizely.ab:android-sdk:4.0.4'
 }
 ```
 


### PR DESCRIPTION
## Summary
- Prepare for release 4.0.4



## Test plan
- N/A

## Issues
- [FSSDK-10674](https://jira.sso.episerver.net/browse/FSSDK-10674)