### PR TITLE
WIP: vuid enabled add to optimizely manager

### DIFF
--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/ODPIntegrationTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/ODPIntegrationTest.java
@@ -100,7 +100,7 @@ public class ODPIntegrationTest {
 
         optimizelyManager = OptimizelyManager.builder()
             .withSDKKey(testSdkKey)
-            .withVuid(testVuid)
+            .withVuidEnabled()
             .withODPEventManager(odpEventManager)
             .withODPSegmentManager(odpSegmentManager)
             .build(context);

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/ODPIntegrationTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/ODPIntegrationTest.java
@@ -29,6 +29,7 @@ import com.optimizely.ab.android.odp.DefaultODPApiManager;
 import com.optimizely.ab.odp.ODPApiManager;
 import com.optimizely.ab.odp.ODPEventManager;
 import com.optimizely.ab.odp.ODPManager;
+import com.optimizely.ab.android.odp.VuidManager;
 import com.optimizely.ab.odp.ODPSegmentManager;
 
 import org.junit.Before;
@@ -107,6 +108,7 @@ public class ODPIntegrationTest {
 
         optimizelyManager.initialize(context, odpDatafile);
         optimizelyClient = optimizelyManager.getOptimizely();
+
     }
 
     @Test
@@ -134,11 +136,11 @@ public class ODPIntegrationTest {
 
         assertEquals(firstEvt.get("action").getAsString(), "client_initialized");
         assertEquals(firstIdentifiers.size(), 1);
-        assertEquals(firstIdentifiers.get("vuid").getAsString(), testVuid);
+        assertTrue(VuidManager.isVuid(firstIdentifiers.get("vuid").getAsString()));
 
         assertEquals(secondEvt.get("action").getAsString(), "identified");
         assertEquals(secondIdentifiers.size(), 2);
-        assertEquals(secondIdentifiers.get("vuid").getAsString(), testVuid);
+        assertTrue(VuidManager.isVuid(secondIdentifiers.get("vuid").getAsString()));
         assertEquals(secondIdentifiers.get("fs_user_id").getAsString(), testUser);
 
         // validate that ODP event data includes correct values.
@@ -170,11 +172,11 @@ public class ODPIntegrationTest {
 
         assertEquals(firstEvt.get("action").getAsString(), "client_initialized");
         assertEquals(firstIdentifiers.size(), 1);
-        assertEquals(firstIdentifiers.get("vuid").getAsString(), testVuid);
+        assertTrue(VuidManager.isVuid(firstIdentifiers.get("vuid").getAsString()));
 
         assertEquals(secondEvt.get("action").getAsString(), "identified");
         assertEquals(secondIdentifiers.size(), 1);
-        assertEquals(secondIdentifiers.get("vuid").getAsString(), testVuid);
+        assertTrue(VuidManager.isVuid(secondIdentifiers.get("vuid").getAsString()));
     }
 
     @Test
@@ -202,7 +204,7 @@ public class ODPIntegrationTest {
             eq("p-1"),
             eq("h-1/v3/graphql"),
             eq("vuid"),
-            eq(testVuid),
+            eq(optimizelyClient.getVuid()),
             eq(new HashSet<>(Arrays.asList("segment-1")))
         );
     }

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/ODPIntegrationUpdateConfigTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/ODPIntegrationUpdateConfigTest.java
@@ -34,6 +34,7 @@ import com.optimizely.ab.notification.NotificationCenter;
 import com.optimizely.ab.odp.ODPApiManager;
 import com.optimizely.ab.odp.ODPEventManager;
 import com.optimizely.ab.odp.ODPManager;
+import com.optimizely.ab.android.odp.VuidManager;
 import com.optimizely.ab.odp.ODPSegmentManager;
 
 import org.junit.Before;
@@ -68,6 +69,7 @@ public class ODPIntegrationUpdateConfigTest {
 
     private OptimizelyManager optimizelyManager;
     private ODPManager odpManager;
+    private VuidManager vuidManager;
     private DefaultDatafileHandler datafileHandler;
     private NotificationCenter notificationCenter;
     private Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
@@ -101,6 +103,7 @@ public class ODPIntegrationUpdateConfigTest {
 
         datafileHandler = new DefaultDatafileHandler();
         notificationCenter = new NotificationCenter();
+        vuidManager = new VuidManager(context, true);
 
         optimizelyManager = new OptimizelyManager(
             null,
@@ -117,7 +120,7 @@ public class ODPIntegrationUpdateConfigTest {
             notificationCenter,
             null,
             odpManager,
-            "test-vuid",
+            vuidManager,
             null,
             null);
     }

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyClientTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyClientTest.java
@@ -2222,7 +2222,7 @@ public class OptimizelyClientTest {
         Optimizely mockOptimizely = mock(Optimizely.class);
         when(mockOptimizely.isValid()).thenReturn(true);
 
-        OptimizelyClient optimizelyClient = new OptimizelyClient(mockOptimizely, logger, "any-vuid");
+        OptimizelyClient optimizelyClient = new OptimizelyClient(mockOptimizely, logger, "vuid_123");
 
         verify(mockOptimizely).sendODPEvent(
                 null,

--- a/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerTest.java
+++ b/android-sdk/src/androidTest/java/com/optimizely/ab/android/sdk/OptimizelyManagerTest.java
@@ -40,6 +40,7 @@ import com.optimizely.ab.config.Variation;
 import com.optimizely.ab.config.parser.ConfigParseException;
 import com.optimizely.ab.event.EventHandler;
 import com.optimizely.ab.event.EventProcessor;
+import com.optimizely.ab.android.odp.VuidManager;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -166,8 +167,10 @@ public class OptimizelyManagerTest {
         DatafileHandler datafileHandler = mock(DefaultDatafileHandler.class);
         EventHandler eventHandler = mock(DefaultEventHandler.class);
         EventProcessor eventProcessor = mock(EventProcessor.class);
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        VuidManager vuidManager = new VuidManager(context, true);
         OptimizelyManager optimizelyManager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, 3600L, datafileHandler, null, 3600L,
-                eventHandler, eventProcessor, null, null, null, null, null, null, null);
+                eventHandler, eventProcessor, null, null, null, null, vuidManager, null, null);
         /*
          * Scenario#1: when datafile is not Empty
          * Scenario#2: when datafile is Empty
@@ -225,8 +228,10 @@ public class OptimizelyManagerTest {
         DatafileHandler datafileHandler = mock(DefaultDatafileHandler.class);
         EventHandler eventHandler = mock(DefaultEventHandler.class);
         EventProcessor eventProcessor = mock(EventProcessor.class);
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        VuidManager vuidManager = new VuidManager(context, true);
         final OptimizelyManager optimizelyManager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, 3600L, datafileHandler, null, 3600L,
-                eventHandler, eventProcessor, null, null, null, null, null, null, null);
+                eventHandler, eventProcessor, null, null, null, null, vuidManager, null, null);
 
         /*
          * Scenario#1: when datafile is not Empty
@@ -496,9 +501,9 @@ public class OptimizelyManagerTest {
         DefaultDatafileHandler datafileHandler = spy(new DefaultDatafileHandler());
         Logger logger = mock(Logger.class);
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
+        VuidManager vuidManager = new VuidManager(context, true);
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, vuidManager, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -529,9 +534,9 @@ public class OptimizelyManagerTest {
         DefaultDatafileHandler datafileHandler = spy(new DefaultDatafileHandler());
         Logger logger = mock(Logger.class);
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
+        VuidManager vuidManager = new VuidManager(context, true);
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, vuidManager, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -562,9 +567,9 @@ public class OptimizelyManagerTest {
         DefaultDatafileHandler datafileHandler = spy(new DefaultDatafileHandler());
         Logger logger = mock(Logger.class);
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
+        VuidManager vuidManager = new VuidManager(context, true);
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, vuidManager, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -595,9 +600,9 @@ public class OptimizelyManagerTest {
         DefaultDatafileHandler datafileHandler = spy(new DefaultDatafileHandler());
         Logger logger = mock(Logger.class);
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
+        VuidManager vuidManager = new VuidManager(context, true);
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, vuidManager, null, null);
 
         doAnswer(
                 (Answer<Object>) invocation -> {
@@ -627,9 +632,9 @@ public class OptimizelyManagerTest {
         DefaultDatafileHandler datafileHandler = spy(new DefaultDatafileHandler());
         Logger logger = mock(Logger.class);
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
+        VuidManager vuidManager = new VuidManager(context, true);
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, vuidManager, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -660,9 +665,9 @@ public class OptimizelyManagerTest {
         DefaultDatafileHandler datafileHandler = spy(new DefaultDatafileHandler());
         Logger logger = mock(Logger.class);
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
+        VuidManager vuidManager = new VuidManager(context, true);
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, vuidManager, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -694,9 +699,9 @@ public class OptimizelyManagerTest {
         DefaultDatafileHandler datafileHandler = spy(new DefaultDatafileHandler());
         Logger logger = mock(Logger.class);
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
+        VuidManager vuidManager = new VuidManager(context, true);
         OptimizelyManager manager = new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, vuidManager, null, null);
 
         doAnswer(
                 new Answer<Object>() {
@@ -727,9 +732,9 @@ public class OptimizelyManagerTest {
         DefaultDatafileHandler datafileHandler = spy(new DefaultDatafileHandler());
         Logger logger = mock(Logger.class);
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
+        VuidManager vuidManager = new VuidManager(context, true);
         OptimizelyManager manager = spy(new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null));
+                null, null, null, null, null, null, vuidManager, null, null));
 
         datafileHandler.removeSavedDatafile(context, manager.getDatafileConfig());
         OptimizelyClient client = manager.initialize(context, R.raw.datafile, downloadToCache, updateConfigOnNewDatafile);
@@ -744,9 +749,9 @@ public class OptimizelyManagerTest {
         DefaultDatafileHandler datafileHandler = spy(new DefaultDatafileHandler());
         Logger logger = mock(Logger.class);
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
+        VuidManager vuidManager = new VuidManager(context, true);
         OptimizelyManager manager = spy(new OptimizelyManager(testProjectId, testSdkKey, null, logger, pollingInterval, datafileHandler, null, 0,
-                null, null, null, null, null, null, null, null, null));
+                null, null, null, null, null, null, vuidManager, null, null));
 
         datafileHandler.removeSavedDatafile(context, manager.getDatafileConfig());
         OptimizelyClient client = manager.initialize(context, R.raw.datafile);

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyClient.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyClient.java
@@ -80,7 +80,7 @@ public class OptimizelyClient {
         So, we start with an empty map of default attributes until the manager is initialized.
         */
 
-        if (isValid()) {
+        if (isValid() && vuid != null && VuidManager.isVuid(vuid)) {
             // identifiers are empty here since vuid will be inserted by java-sdk core
             sendODPEvent(null, "client_initialized", null, null);
         }

--- a/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
+++ b/android-sdk/src/main/java/com/optimizely/ab/android/sdk/OptimizelyManager.java
@@ -94,7 +94,7 @@ public class OptimizelyManager {
 
     @NonNull private UserProfileService userProfileService;
     @Nullable private ODPManager odpManager;
-    private VuidManager vuidManager;
+    @Nullable private VuidManager vuidManager;
     @Nullable private OptimizelyStartListener optimizelyStartListener;
     private boolean returnInMainThreadFromAsyncInit = true;
 
@@ -116,7 +116,7 @@ public class OptimizelyManager {
                       @NonNull NotificationCenter notificationCenter,
                       @Nullable List<OptimizelyDecideOption> defaultDecideOptions,
                       @Nullable ODPManager odpManager,
-                      VuidManager vuidManger,
+                      @Nullable VuidManager vuidManger,
                       @Nullable String clientEngineName,
                       @Nullable String clientVersion) {
 

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
@@ -250,7 +250,7 @@ public class OptimizelyManagerBuilderTest {
             any(NotificationCenter.class),
             any(),                         // nullable (DefaultDecideOptions)
             any(ODPManager.class),
-            eq("test-vuid"),
+            any(VuidManager.class),
             any(),
             any());
     }
@@ -280,7 +280,7 @@ public class OptimizelyManagerBuilderTest {
             any(NotificationCenter.class),
             any(),                         // nullable (DefaultDecideOptions)
             isNull(),
-            eq("test-vuid"),
+            any(VuidManager.class),
             any(),
             any());
     }

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerBuilderTest.java
@@ -115,7 +115,7 @@ public class OptimizelyManagerBuilderTest {
         OptimizelyManager manager = OptimizelyManager.builder()
                 .withSDKKey(testSdkKey)
                 .withDatafileDownloadInterval(interval, timeUnit)
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .build(mockContext);
 
         assertEquals(interval * 60L, manager.getDatafileDownloadInterval().longValue());
@@ -128,7 +128,7 @@ public class OptimizelyManagerBuilderTest {
                 .withSDKKey(testSdkKey)
                 .withDatafileDownloadInterval(901L, TimeUnit.SECONDS)
                 .withEventHandler(eventHandler)
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .build(mockContext);
 
         assertEquals(901L, manager.getDatafileDownloadInterval().longValue());
@@ -142,7 +142,7 @@ public class OptimizelyManagerBuilderTest {
                 .withSDKKey(testSdkKey)
                 .withDatafileDownloadInterval(61L, TimeUnit.SECONDS)
                 .withErrorHandler(errorHandler)
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .build(mockContext);
 
         manager.initialize(mockContext, minDatafile);
@@ -157,7 +157,7 @@ public class OptimizelyManagerBuilderTest {
                 .withSDKKey(testSdkKey)
                 .withDatafileDownloadInterval(61L, TimeUnit.SECONDS)
                 .withDatafileHandler(dfHandler)
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .build(mockContext);
 
         manager.initialize(mockContext, minDatafile);
@@ -172,7 +172,7 @@ public class OptimizelyManagerBuilderTest {
                 .withSDKKey(testSdkKey)
                 .withDatafileDownloadInterval(61L, TimeUnit.SECONDS)
                 .withUserProfileService(ups)
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .build(mockContext);
 
         manager.initialize(mockContext, minDatafile);
@@ -189,7 +189,7 @@ public class OptimizelyManagerBuilderTest {
                 .withSDKKey(testSdkKey)
                 .withDatafileHandler(mockDatafileHandler)
                 .withDatafileDownloadInterval(goodNumber, TimeUnit.MINUTES)
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .build(mockContext);
         OptimizelyManager spyManager = spy(manager);
         when(spyManager.isAndroidVersionSupported()).thenReturn(true);
@@ -205,7 +205,7 @@ public class OptimizelyManagerBuilderTest {
                 .withSDKKey(testSdkKey)
                 .withDatafileHandler(mockDatafileHandler)
                 .withDatafileDownloadInterval(-1, TimeUnit.MINUTES)
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .build(mockContext);
         OptimizelyManager spyManager = spy(manager);
         when(spyManager.isAndroidVersionSupported()).thenReturn(true);
@@ -220,7 +220,7 @@ public class OptimizelyManagerBuilderTest {
         OptimizelyManager manager = OptimizelyManager.builder()
             .withSDKKey(testSdkKey)
             .withClientInfo("test-sdk", "test-version")
-            .withVuid("any-to-avoid-generate")
+            .withVuidEnabled()
             .build(mockContext);
         assertEquals(manager.getSdkName(mockContext), "test-sdk");
         assertEquals(manager.getSdkVersion(), "test-version");
@@ -232,7 +232,7 @@ public class OptimizelyManagerBuilderTest {
 
         OptimizelyManager manager = OptimizelyManager.builder()
                 .withSDKKey(testSdkKey)
-                .withVuid("test-vuid")
+                .withVuidEnabled()
                 .build(mockContext);
 
         verifyNew(OptimizelyManager.class).withArguments(
@@ -262,7 +262,7 @@ public class OptimizelyManagerBuilderTest {
         OptimizelyManager manager = OptimizelyManager.builder()
             .withSDKKey(testSdkKey)
             .withODPDisabled()
-            .withVuid("test-vuid")
+            .withVuidEnabled()
             .build(mockContext);
 
         verifyNew(OptimizelyManager.class).withArguments(
@@ -293,7 +293,7 @@ public class OptimizelyManagerBuilderTest {
 
         OptimizelyManager manager = OptimizelyManager.builder()
                 .withSDKKey(testSdkKey)
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .build(mockContext);
 
         verifyNew(ODPManager.class).withArguments(
@@ -320,7 +320,7 @@ public class OptimizelyManagerBuilderTest {
         OptimizelyManager manager = OptimizelyManager.builder()
             .withSDKKey(testSdkKey)
             .withODPSegmentCacheSize(1234)
-            .withVuid("any-to-avoid-generate")
+            .withVuidEnabled()
             .build(mockContext);
 
         verifyNew(ODPSegmentManager.class).withArguments(
@@ -337,7 +337,7 @@ public class OptimizelyManagerBuilderTest {
         OptimizelyManager manager = OptimizelyManager.builder()
             .withSDKKey(testSdkKey)
             .withODPSegmentCacheTimeout(20, TimeUnit.MINUTES)
-            .withVuid("any-to-avoid-generate")
+            .withVuidEnabled()
             .build(mockContext);
 
         verifyNew(ODPSegmentManager.class).withArguments(
@@ -351,7 +351,7 @@ public class OptimizelyManagerBuilderTest {
     public void testBuildWithODP_defaultSegmentFetchTimeout() throws Exception {
         OptimizelyManager manager = OptimizelyManager.builder()
             .withSDKKey(testSdkKey)
-            .withVuid("any-to-avoid-generate")
+            .withVuidEnabled()
             .build(mockContext);
 
         assertEquals(ODPSegmentClient.Companion.getCONNECTION_TIMEOUT(), 10*1000);
@@ -364,7 +364,7 @@ public class OptimizelyManagerBuilderTest {
             .withSDKKey(testSdkKey)
             .withTimeoutForODPSegmentFetch(20)
             .withTimeoutForODPEventDispatch(30)
-            .withVuid("any-to-avoid-generate")
+            .withVuidEnabled()
             .build(mockContext);
 
         assertEquals(ODPSegmentClient.Companion.getCONNECTION_TIMEOUT(), 20*1000);
@@ -380,7 +380,7 @@ public class OptimizelyManagerBuilderTest {
 
         OptimizelyManager manager = OptimizelyManager.builder()
             .withSDKKey(testSdkKey)
-            .withVuid("test-vuid")
+            .withVuidEnabled()
             .build(mockContext);
 
         ArgumentCaptor<Map<String, Object>> captorData = ArgumentCaptor.forClass(Map.class);

--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerIntervalTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/OptimizelyManagerIntervalTest.java
@@ -84,7 +84,7 @@ public class OptimizelyManagerIntervalTest {
     public void testBuildWithDatafileDownloadInterval() throws Exception {
         long goodNumber = 27;
         OptimizelyManager manager = OptimizelyManager.builder("1")
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .withLogger(logger)
                 .withDatafileDownloadInterval(goodNumber, TimeUnit.MINUTES)
                 .build(mockContext);
@@ -113,7 +113,7 @@ public class OptimizelyManagerIntervalTest {
     public void testBuildWithDatafileDownloadIntervalDeprecated() throws Exception {
         long goodNumber = 1234L;
         OptimizelyManager manager = OptimizelyManager.builder("1")
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .withLogger(logger)
                 .withDatafileDownloadInterval(goodNumber)      // deprecated
                 .build(mockContext);
@@ -142,7 +142,7 @@ public class OptimizelyManagerIntervalTest {
     public void testBuildWithEventDispatchInterval() throws Exception {
         long goodNumber = 100L;
         OptimizelyManager manager = OptimizelyManager.builder("1")
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .withLogger(logger)
                 .withEventDispatchInterval(goodNumber, TimeUnit.SECONDS)
                 .build(mockContext);
@@ -186,7 +186,7 @@ public class OptimizelyManagerIntervalTest {
         long defaultEventFlushInterval = 30L;   // seconds
 
         OptimizelyManager manager = OptimizelyManager.builder("1")
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .withLogger(logger)
                 .withEventDispatchRetryInterval(goodNumber, timeUnit)
                 .build(mockContext);
@@ -227,7 +227,7 @@ public class OptimizelyManagerIntervalTest {
     public void testBuildWithEventDispatchIntervalDeprecated() throws Exception {
         long goodNumber = 1234L;
         OptimizelyManager manager = OptimizelyManager.builder("1")
-                .withVuid("any-to-avoid-generate")
+                .withVuidEnabled()
                 .withLogger(logger)
                 .withEventDispatchInterval(goodNumber)      // deprecated
                 .build(mockContext);

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Thu Jan 28 11:38:35 PST 2021
+#Fri Oct 18 20:28:21 BDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-org.gradle.jvmargs=-Xmx1g
-zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+org.gradle.jvmargs=-Xmx1g
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/odp/src/androidTest/java/com/optimizely/ab/android/odp/VuidManagerTest.kt
+++ b/odp/src/androidTest/java/com/optimizely/ab/android/odp/VuidManagerTest.kt
@@ -90,25 +90,35 @@ class VuidManagerTest {
 
     @Test
     fun autoLoaded() {
-        val vuid1 = VuidManager.getShared(context).vuid
+        val vuidManager1 = VuidManager(context, true)
+        val vuid1 = vuidManager1.vuid
         assertTrue("vuid should be auto loaded when constructed", vuid1.startsWith("vuid_"))
+        val savedVuid = vuidManager1.load(context)
+        assertEquals("Vuid should be same", vuid1, savedVuid)
 
-        val vuid2 = VuidManager.getShared(context).vuid
-        assertEquals("the same vuid should be returned when getting a singleton", vuid1, vuid2)
+        val vuidManager2 = VuidManager(context, false)
+        val vuid2 = vuidManager2.vuid
+        assertTrue(vuid2 == "")
+        assertFalse("vuid should be auto loaded when constructed", vuid2.startsWith("vuid_"))
 
-        // remove shared instance, so will be re-instantiated
-        VuidManager.removeSharedForTesting()
 
-        val vuid3 = VuidManager.getShared(context).vuid
-        assertEquals("the saved vuid should be returned when instantiated again", vuid2, vuid3)
 
-        // remove saved vuid
-        cleanSharedPrefs()
-        // remove shared instance, so will be re-instantiated
-        VuidManager.removeSharedForTesting()
-
-        val vuid4 = VuidManager.getShared(context).vuid
-        assertNotEquals("a new vuid should be returned when storage cleared and re-instantiated", vuid3, vuid4)
-        assertTrue(vuid4.startsWith("vuid_"))
+//        val vuid2 = VuidManager.getShared(context).vuid
+//        assertEquals("the same vuid should be returned when getting a singleton", vuid1, vuid2)
+//
+//        // remove shared instance, so will be re-instantiated
+//        VuidManager.removeSharedForTesting()
+//
+//        val vuid3 = VuidManager.getShared(context).vuid
+//        assertEquals("the saved vuid should be returned when instantiated again", vuid2, vuid3)
+//
+//        // remove saved vuid
+//        cleanSharedPrefs()
+//        // remove shared instance, so will be re-instantiated
+//        VuidManager.removeSharedForTesting()
+//
+//        val vuid4 = VuidManager.getShared(context).vuid
+//        assertNotEquals("a new vuid should be returned when storage cleared and re-instantiated", vuid3, vuid4)
+//        assertTrue(vuid4.startsWith("vuid_"))
     }
 }

--- a/odp/src/main/java/com/optimizely/ab/android/odp/VuidManager.kt
+++ b/odp/src/main/java/com/optimizely/ab/android/odp/VuidManager.kt
@@ -36,27 +36,18 @@ class VuidManager constructor(context: Context, isEnabled: Boolean = false) {
     fun getVuid(): String? {
         return if (isEnabled) this._vuid else null
     }
+
     fun isEnabled(): Boolean {
         return isEnabled
     }
 
     companion object {
-//        @Volatile
-//        private var INSTANCE: VuidManager? = null
-
-        @Synchronized
-//        fun getShared(context: Context): VuidManager = INSTANCE ?: VuidManager(context).also { INSTANCE = it }
-
+        @JvmStatic
         fun isVuid(visitorId: String): Boolean {
             return visitorId.startsWith("vuid_", ignoreCase = true)
         }
-
-//        @VisibleForTesting
-//        fun removeSharedForTesting() {
-//            INSTANCE = null
-//        }
     }
-
+    
     @VisibleForTesting
     fun makeVuid(): String {
         val maxLength = 32 // required by ODP server

--- a/odp/src/main/java/com/optimizely/ab/android/odp/VuidManager.kt
+++ b/odp/src/main/java/com/optimizely/ab/android/odp/VuidManager.kt
@@ -19,29 +19,42 @@ import androidx.annotation.VisibleForTesting
 import com.optimizely.ab.android.shared.OptlyStorage
 import java.util.UUID
 
-class VuidManager private constructor(context: Context) {
-    var vuid = ""
+class VuidManager constructor(context: Context, isEnabled: Boolean = false) {
+    private var _vuid = ""
     private val keyForVuid = "vuid" // stored in the private "optly" storage
+    private var isEnabled: Boolean = isEnabled
 
     init {
-        this.vuid = load(context)
+        if (isEnabled) {
+            this._vuid = load(context)
+        } else {
+            this.remove(context)
+        }
+
+    }
+
+    fun getVuid(): String? {
+        return if (isEnabled) this._vuid else null
+    }
+    fun isEnabled(): Boolean {
+        return isEnabled
     }
 
     companion object {
-        @Volatile
-        private var INSTANCE: VuidManager? = null
+//        @Volatile
+//        private var INSTANCE: VuidManager? = null
 
         @Synchronized
-        fun getShared(context: Context): VuidManager = INSTANCE ?: VuidManager(context).also { INSTANCE = it }
+//        fun getShared(context: Context): VuidManager = INSTANCE ?: VuidManager(context).also { INSTANCE = it }
 
         fun isVuid(visitorId: String): Boolean {
             return visitorId.startsWith("vuid_", ignoreCase = true)
         }
 
-        @VisibleForTesting
-        fun removeSharedForTesting() {
-            INSTANCE = null
-        }
+//        @VisibleForTesting
+//        fun removeSharedForTesting() {
+//            INSTANCE = null
+//        }
     }
 
     @VisibleForTesting
@@ -68,5 +81,11 @@ class VuidManager private constructor(context: Context) {
     fun save(context: Context, vuid: String) {
         val storage = OptlyStorage(context)
         storage.saveString(keyForVuid, vuid)
+    }
+
+    @VisibleForTesting
+    fun remove(context: Context) {
+        val storage = OptlyStorage(context)
+        storage.removeString(keyForVuid)
     }
 }

--- a/odp/src/main/java/com/optimizely/ab/android/odp/VuidManager.kt
+++ b/odp/src/main/java/com/optimizely/ab/android/odp/VuidManager.kt
@@ -47,7 +47,7 @@ class VuidManager constructor(context: Context, isEnabled: Boolean = false) {
             return visitorId.startsWith("vuid_", ignoreCase = true)
         }
     }
-    
+
     @VisibleForTesting
     fun makeVuid(): String {
         val maxLength = 32 // required by ODP server

--- a/shared/src/main/java/com/optimizely/ab/android/shared/OptlyStorage.java
+++ b/shared/src/main/java/com/optimizely/ab/android/shared/OptlyStorage.java
@@ -72,6 +72,14 @@ public class OptlyStorage {
     public void saveString(String key, String value) {
         getWritablePrefs().putString(key, value).apply();
     }
+    /**
+     * Remove a string value
+     * @param key a String key
+     * @hide
+     */
+    public void removeString(String key) {
+        getWritablePrefs().remove(key).apply();
+    }
 
     /**
      * Get a string value


### PR DESCRIPTION
## Summary
- Make vuid feature as opt-in.
- Reference PR: https://github.com/optimizely/javascript-sdk/pull/950/files
 ## Logical changes when vuid is not enabled 
- vuid is not generated/saved.
- Delete any existing vuid (leftover by previous init).
- “client-intialized” event not auto-fired.
- vuid is not included in ODP events as a default attribuite for tracking. 
- createUserContext() will be rejected when userId is not provided.


## Test plan

## Issues
- [FSSDK-10758](https://jira.sso.episerver.net/browse/FSSDK-10758)