### PR TITLE
[FSSDK-10769] bump java sdk to version 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,4 @@ License (Public Domain): [https://github.com/noveogroup/android-logger/blob/mast
 - Ruby - https://github.com/optimizely/ruby-sdk
 
 - Swift - https://github.com/optimizely/swift-sdk
+

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext {
     build_tools_version = "30.0.3"
     min_sdk_version = 21
     target_sdk_version = 33
-    java_core_ver = "4.0.0"
+    java_core_ver = "4.2.0"
     android_logger_ver = "1.3.6"
     jacksonversion= "2.11.2"
     annotations_ver = "1.2.0"


### PR DESCRIPTION
## Summary
- bump java sdk to version 4.2.0

## Test plan
- all existing tests should pass

## Issues
- FSSDK-10769