### PR TITLE
[FSSDK-11076] chore: remove travis details from doc

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -72,7 +72,7 @@ jobs:
         echo "$GITHUB_CONTEXT"
         home/runner/ci-helper-tools/trigger-script-with-status-update.sh
   build:
-    uses: optimizely/android-sdk/.github/workflows/build.yml@muzahid/remove-travis
+    uses: optimizely/android-sdk/.github/workflows/build.yml@master
     with:
       action: build
   test:
@@ -135,7 +135,7 @@ jobs:
           script: ./gradlew testAllModules
   publish:
     if: startsWith(github.ref, 'refs/tags/')
-    uses: optimizely/android-sdk/.github/workflows/build.yml@muzahid/remove-travis
+    uses: optimizely/android-sdk/.github/workflows/build.yml@master
     with:
       action: ship
       github_tag: ${GITHUB_REF#refs/*/}
@@ -147,7 +147,7 @@ jobs:
       
   snapshot:
     if: ${{ github.event.inputs.SNAPSHOT == 'true' && github.event_name == 'workflow_dispatch' }}
-    uses: optimizely/android-sdk/.github/workflows/build.yml@muzahid/remove-travis
+    uses: optimizely/android-sdk/.github/workflows/build.yml@master
     with:
       action: ship
       github_tag: BB-SNAPSHOT

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -135,7 +135,21 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew testAllModulesTravis
+          script: ./gradlew task testAllModules () {
+    logger.info("Running android tests for all modules")
+    dependsOn('testAllModules', ':test-app:connectedAndroidTest')
+}
+
+  task testAllModules () {
+  logger.info("Running android tests for Travis")
+  dependsOn(':android-sdk:connectedAndroidTest', ':android-sdk:test',
+  ':event-handler:connectedAndroidTest', ':event-handler:test',
+  ':datafile-handler:connectedAndroidTest', ':datafile-handler:test',
+  ':user-profile:connectedAndroidTest',
+  ':shared:connectedAndroidTest',
+  ':odp:connectedAndroidTest', ':odp:test'
+  )
+}
   publish:
     if: startsWith(github.ref, 'refs/tags/')
     uses: optimizely/android-sdk/.github/workflows/build.yml@master

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,8 +35,8 @@ jobs:
       with:
         # You should create a personal access token and store it in your repository
         token: ${{ secrets.CI_USER_TOKEN }}
-        repository: 'optimizely/travisci-tools'
-        path: 'home/runner/travisci-tools'
+        repository: 'optimizely/ci-helper-tools'
+        path: 'home/runner/ci-helper-tools'
         ref: 'master'
       
     - name: set SDK Branch if PR
@@ -45,14 +45,12 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       run: |
         echo "SDK_BRANCH=$HEAD_REF" >> $GITHUB_ENV
-        echo "TRAVIS_BRANCH=$HEAD_REF" >> $GITHUB_ENV
     - name: set SDK Branch if not pull request
       env:
         REF_NAME: ${{github.ref_name}}
       if: ${{ github.event_name != 'pull_request' }}
       run: |
         echo "SDK_BRANCH=$REF_NAME" >> $GITHUB_ENV
-        echo "TRAVIS_BRANCH=$REF_NAME" >> $GITHUB_ENV
     - name: Trigger build
       env:
         SDK: android
@@ -68,14 +66,13 @@ jobs:
         PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
         PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         UPSTREAM_SHA: ${{ github.sha }}
-        TOKEN: ${{ secrets.TRAVIS_COM_TOKEN }}
         EVENT_MESSAGE: ${{ github.event.message }}
         HOME: 'home/runner'
       run: |
         echo "$GITHUB_CONTEXT"
-        home/runner/travisci-tools/trigger-script-with-status-update.sh
+        home/runner/ci-helper-tools/trigger-script-with-status-update.sh
   build:
-    uses: optimizely/android-sdk/.github/workflows/build.yml@master
+    uses: optimizely/android-sdk/.github/workflows/build.yml@muzahid/remove-travis
     with:
       action: build
   test:
@@ -141,7 +138,7 @@ jobs:
     uses: optimizely/android-sdk/.github/workflows/build.yml@master
     with:
       action: ship
-      travis_tag: ${GITHUB_REF#refs/*/}
+      github_tag: ${GITHUB_REF#refs/*/}
     secrets:
       MAVEN_SIGNING_KEY_BASE64: ${{ secrets.MAVEN_SIGNING_KEY_BASE64 }}
       MAVEN_SIGNING_PASSPHRASE: ${{ secrets.MAVEN_SIGNING_PASSPHRASE }}
@@ -153,7 +150,7 @@ jobs:
     uses: optimizely/android-sdk/.github/workflows/build.yml@master
     with:
       action: ship
-      travis_tag: BB-SNAPSHOT
+      github_tag: BB-SNAPSHOT
     secrets:
       MAVEN_SIGNING_KEY_BASE64: ${{ secrets.MAVEN_SIGNING_KEY_BASE64 }}
       MAVEN_SIGNING_PASSPHRASE: ${{ secrets.MAVEN_SIGNING_PASSPHRASE }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -135,7 +135,7 @@ jobs:
           script: ./gradlew testAllModules
   publish:
     if: startsWith(github.ref, 'refs/tags/')
-    uses: optimizely/android-sdk/.github/workflows/build.yml@master
+    uses: optimizely/android-sdk/.github/workflows/build.yml@muzahid/remove-travis
     with:
       action: ship
       github_tag: ${GITHUB_REF#refs/*/}
@@ -147,7 +147,7 @@ jobs:
       
   snapshot:
     if: ${{ github.event.inputs.SNAPSHOT == 'true' && github.event_name == 'workflow_dispatch' }}
-    uses: optimizely/android-sdk/.github/workflows/build.yml@master
+    uses: optimizely/android-sdk/.github/workflows/build.yml@muzahid/remove-travis
     with:
       action: ship
       github_tag: BB-SNAPSHOT

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -135,21 +135,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew task testAllModules () {
-    logger.info("Running android tests for all modules")
-    dependsOn('testAllModules', ':test-app:connectedAndroidTest')
-}
-
-  task testAllModules () {
-  logger.info("Running android tests for Travis")
-  dependsOn(':android-sdk:connectedAndroidTest', ':android-sdk:test',
-  ':event-handler:connectedAndroidTest', ':event-handler:test',
-  ':datafile-handler:connectedAndroidTest', ':datafile-handler:test',
-  ':user-profile:connectedAndroidTest',
-  ':shared:connectedAndroidTest',
-  ':odp:connectedAndroidTest', ':odp:test'
-  )
-}
+          script: ./gradlew testAllModules
   publish:
     if: startsWith(github.ref, 'refs/tags/')
     uses: optimizely/android-sdk/.github/workflows/build.yml@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       action:
         required: true
         type: string
-      travis_tag:
+      github_tag:
         required: false
         type: string
     secrets:
@@ -39,4 +39,4 @@ jobs:
         MAVEN_SIGNING_PASSPHRASE: ${{ secrets.MAVEN_SIGNING_PASSPHRASE }}
         MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-      run: TRAVIS_TAG=${{ inputs.travis_tag }} ./gradlew ${{ inputs.action }}
+      run: github_tag=${{ inputs.github_tag }} ./gradlew ${{ inputs.action }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ We welcome contributions and feedback! All contributors must sign our [Contribut
 7. Open a pull request from `YOUR_NAME/branch_name` to `master`.
 8. A repository maintainer will review your pull request and, if all goes well, squash and merge it!
 
-All branches will be built and run against the entire test suite on Travis with every commit.
+All branches will be built and run against the entire test suite on Gtihub Actions with every commit.
 
 The `test-app` module is built against a real Optimizely project. Changing the project ID will cause tests to fail. The test app should be used as a reference.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Optimizely Android SDK
 [![Apache 2.0](https://img.shields.io/github/license/nebula-plugins/gradle-extra-configurations-plugin.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-[![Build Status](https://travis-ci.org/optimizely/android-sdk.svg?branch=master)](https://travis-ci.org/optimizely/android-sdk)
 
 This repository houses the Android SDK for use with Optimizely Feature Experimentation and Optimizely Full Stack (legacy). The Android SDK depends on the [Optimizely Java SDK](https://github.com/optimizely/java-sdk).
 

--- a/build.gradle
+++ b/build.gradle
@@ -102,11 +102,6 @@ task cleanAllModules () {
 
 task testAllModules () {
     logger.info("Running android tests for all modules")
-    dependsOn('testAllModulesTravis', ':test-app:connectedAndroidTest')
-}
-
-task testAllModulesTravis () {
-    logger.info("Running android tests for Travis")
     dependsOn(':android-sdk:connectedAndroidTest', ':android-sdk:test',
             ':event-handler:connectedAndroidTest', ':event-handler:test',
             ':datafile-handler:connectedAndroidTest', ':datafile-handler:test',


### PR DESCRIPTION
## Summary
- Remove travis build status
- Rename `testAllModulesTravis` task to `testAllModules`

## Test plan
- N/A

## Issues
- [FSSDK-11076](https://jira.sso.episerver.net/browse/FSSDK-11076)