### PR TITLE
[AI-FSSDK] prepare for release android-sdk v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,17 @@ Feature Rollouts enable progressive rollouts with full impact analytics, metric 
 and confidence intervals.
 See [Feature Rollout docs](https://support.optimizely.com/hc/en-us/articles/45552846481037-Run-Feature-Rollouts-in-Feature-Experimentation) for more information.
 
-- Fix old test issues with mockito versions ([#527](https://github.com/optimizely/android-sdk/pull/527))
-- Add Feature Rollout support ([#524](https://github.com/optimizely/android-sdk/pull/524))
-- Remove source clear cron workflow ([#523](https://github.com/optimizely/android-sdk/pull/523))
+- Upgrade dependency to [Java SDK 4.4.0](https://github.com/optimizely/java-sdk/releases/tag/4.4.0)
+
+### Fixes and Improvements
+
 - Update cmab error handling ([#522](https://github.com/optimizely/android-sdk/pull/522))
-- Option to run local java-sdk lib ([#521](https://github.com/optimizely/android-sdk/pull/521))
+
 
 ## 5.1.1
 January 20th, 2025
 
-### Enhancements and fixes
+### Fixes and Improvements
 * Upgrade Java Core SDK to 4.3.1 from 4.3.0.
 * Excludes CMAB from UserProfileService.
 * Fixes missing bucketing reasons in CMAB decision path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Optimizely Android X SDK Changelog
 
+## 5.2.0
+May 8, 2026
+
+### New Features
+
+**Feature Rollout**: Added support for Feature Rollouts, a new experiment type
+combining Targeted Delivery simplicity with A/B test measurement capabilities.
+Feature Rollouts enable progressive rollouts with full impact analytics, metric tracking,
+and confidence intervals.
+See [Feature Rollout docs](https://support.optimizely.com/hc/en-us/articles/45552846481037-Run-Feature-Rollouts-in-Feature-Experimentation) for more information.
+
+- Fix old test issues with mockito versions ([#527](https://github.com/optimizely/android-sdk/pull/527))
+- Add Feature Rollout support ([#524](https://github.com/optimizely/android-sdk/pull/524))
+- Remove source clear cron workflow ([#523](https://github.com/optimizely/android-sdk/pull/523))
+- Update cmab error handling ([#522](https://github.com/optimizely/android-sdk/pull/522))
+- Option to run local java-sdk lib ([#521](https://github.com/optimizely/android-sdk/pull/521))
+
 ## 5.1.1
 January 20th, 2025
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.optimizely.ab:android-sdk:5.1.0'
+	implementation 'com.optimizely.ab:android-sdk:5.2.0'
 }
 ```
 


### PR DESCRIPTION
## Summary

Prepare for release v5.2.0

## Release Details
- Version Bump: v5.1.1 → v5.2.0 (minor)

[FSSDK-12546](https://optimizely-ext.atlassian.net/browse/FSSDK-12546)

[FSSDK-12546]: https://optimizely-ext.atlassian.net/browse/FSSDK-12546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ