### PR TITLE
[BUG-8620] Add ProGuard keep rules for Jackson naming strategy

### DIFF
--- a/proguard-rules.txt
+++ b/proguard-rules.txt
@@ -38,6 +38,17 @@
 
 # Safely ignore warnings about other libraries since we are using Gson
 -dontwarn com.fasterxml.jackson.**
+
+# Keep Jackson naming strategy fields used via reflection by the Java SDK serializer (BUG-8620).
+# When Jackson is on the classpath, JacksonSerializer uses reflection to access SNAKE_CASE.
+# Without these rules, R8 obfuscates the field names, causing NoSuchFieldException.
+-keepclassmembers class com.fasterxml.jackson.databind.PropertyNamingStrategies {
+    public static *;
+}
+-keepclassmembers class com.fasterxml.jackson.databind.PropertyNamingStrategy {
+    public static *;
+}
+
 -dontwarn org.json.**
 
 # Annotations


### PR DESCRIPTION
## Summary
- Adds `-keepclassmembers` rules for `PropertyNamingStrategies` and `PropertyNamingStrategy` to prevent R8 from obfuscating the `SNAKE_CASE` field that `JacksonSerializer.getSnakeCaseStrategy()` accesses via reflection
- These are consumer ProGuard rules (automatically applied to apps depending on the SDK)
- Defense-in-depth: prevents the R8 obfuscation issue at the ProGuard level, complementing the primary fix in java-sdk

## Context
PetSmart has Jackson on their classpath as a transitive dependency, with a keep rule preserving `ObjectMapper` class name but not `PropertyNamingStrategies`. R8 obfuscates the `SNAKE_CASE` field, causing `NoSuchFieldException` → `RuntimeException` → `NoClassDefFoundError` in `DefaultJsonSerializer`.

Same class of bug as ae380e92 ("R8: Keep name of `Gson` class (#493)").

**Companion PR:** optimizely/java-sdk#626 (primary resilience fix)

## Test plan
- [ ] Build test-app with `minifyEnabled true` and Jackson on classpath
- [ ] Verify events dispatch successfully without custom EventHandler workaround

## Issue
- [BUG-8620](https://optimizely-ext.atlassian.net/browse/BUG-8620)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BUG-8620]: https://optimizely-ext.atlassian.net/browse/BUG-8620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ