### PR TITLE
[AI-FSSDK] [FSSDK-12670] Block ODP identify event for single identifier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
     build_tools_version = "35.0.0"
     min_sdk_version = 21
     target_sdk_version = 35
-    java_core_ver = "4.4.0"
+    java_core_ver = "4.4.0--NEED-UPDATE"
     android_logger_ver = "1.3.6"
     jacksonversion= "2.11.2"
     annotations_ver = "1.2.0"

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
     build_tools_version = "35.0.0"
     min_sdk_version = 21
     target_sdk_version = 35
-    java_core_ver = "4.4.0--NEED-UPDATE"
+    java_core_ver = "4.4.0"
     android_logger_ver = "1.3.6"
     jacksonversion= "2.11.2"
     annotations_ver = "1.2.0"


### PR DESCRIPTION
## Summary

Bumps java_core_ver to pick up Java SDK core-api changes that fix the ODP identify event to only send when multiple valid identifiers exist. The core logic change lives in the Java SDK's core-api module, which Android inherits automatically.

## Changes
- Bumped java_core_ver with --NEED-UPDATE suffix to flag pending Java core-api release
- Underlying fix: ODPEventManager.identifyUser now skips sending when fewer than 2 valid identifiers remain

## Jira Ticket
[FSSDK-12670](https://optimizely-ext.atlassian.net/browse/FSSDK-12670)

## Notes
- java_core_ver version marked with --NEED-UPDATE suffix - update to actual released version before merging
- Reference: Java SDK PR optimizely/java-sdk#629

[FSSDK-12670]: https://optimizely-ext.atlassian.net/browse/FSSDK-12670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ