### PR TITLE
[AI-FSSDK] [release] prepare for release android v5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Optimizely Android X SDK Changelog
 
+## 5.2.1
+May 28, 2026
+
+### Fixes
+
 ## 5.2.0
 May 8, 2026
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.optimizely.ab:android-sdk:5.2.0'
+	implementation 'com.optimizely.ab:android-sdk:5.2.1'
 }
 ```
 


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md with 5.2.1 entry (May 28, 2026)
- Bump version in README.md from 5.2.0 to 5.2.1

### Commits
- `e016c542` [release] bump version to 5.2.1
- `9d092603` [release] update CHANGELOG for android v5.2.1

🤖 Generated with [Claude Code](https://claude.ai/code)