### PR TITLE
[AI-FSSDK] [release] prepare for release android v5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Optimizely Android X SDK Changelog
 
+## 5.2.1
+May 28, 2026
+
+### Fixes
+
 ## 5.2.0
 May 8, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ May 28, 2026
 
 ### Fixes
 
+- Upgrade dependency to [Java SDK 4.4.1](https://github.com/optimizely/java-sdk/releases/tag/v4.4.1)
+  - Block ODP identify event for single identifier ([#629](https://github.com/optimizely/java-sdk/pull/629))
+  - Add local holdouts support ([#628](https://github.com/optimizely/java-sdk/pull/628))
+
 ## 5.2.0
 May 8, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ May 28, 2026
 ### Fixes
 
 - Upgrade dependency to [Java SDK 4.4.1](https://github.com/optimizely/java-sdk/releases/tag/v4.4.1)
-  - Block ODP identify event for single identifier ([#629](https://github.com/optimizely/java-sdk/pull/629))
-  - Add local holdouts support ([#628](https://github.com/optimizely/java-sdk/pull/628))
+  - Block ODP identify event for single identifier
 
 ## 5.2.0
 May 8, 2026

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.optimizely.ab:android-sdk:5.2.0'
+	implementation 'com.optimizely.ab:android-sdk:5.2.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
     build_tools_version = "35.0.0"
     min_sdk_version = 21
     target_sdk_version = 35
-    java_core_ver = "4.4.0"
+    java_core_ver = "4.4.1"
     android_logger_ver = "1.3.6"
     jacksonversion= "2.11.2"
     annotations_ver = "1.2.0"


### PR DESCRIPTION
## Summary

Prepare for releasing android v5.2.1

## Release Details
- Version Bump: v5.2.0 → v5.2.1 (patch)

## Commits
- e016c542 [release] bump version to 5.2.1
- 9d092603 [release] update CHANGELOG for android v5.2.1