### PR TITLE
[AI-FSSDK] [FSSDK-12750] Use attribute id instead of key for CMAB predictions

### DIFF
--- a/android-sdk/src/test/java/com/optimizely/ab/android/sdk/cmab/DefaultCmabClientTest.java
+++ b/android-sdk/src/test/java/com/optimizely/ab/android/sdk/cmab/DefaultCmabClientTest.java
@@ -1,4 +1,4 @@
-// Copyright 2025, Optimizely, Inc. and contributors
+// Copyright 2025, 2026, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,8 +55,8 @@ public class DefaultCmabClientTest {
         mockCmabClientHelper = spy(new CmabClientHelperAndroid());
 
         testAttributes = new HashMap<>();
-        testAttributes.put("age", 25);
-        testAttributes.put("country", "US");
+        testAttributes.put("66", 25);
+        testAttributes.put("77", "US");
     }
 
     @Test
@@ -308,5 +308,21 @@ public class DefaultCmabClientTest {
         verify(mockClient).execute(any(Client.Request.class), eq(DefaultCmabClient.REQUEST_BACKOFF_TIMEOUT), eq(DefaultCmabClient.REQUEST_RETRIES_POWER));
         assertEquals("REQUEST_BACKOFF_TIMEOUT should be 1", 1, DefaultCmabClient.REQUEST_BACKOFF_TIMEOUT);
         assertEquals("REQUEST_RETRIES_POWER should be 1", 1, DefaultCmabClient.REQUEST_RETRIES_POWER);
+    }
+
+    @Test
+    public void testBuildRequestJsonUsesAttributeIds() {
+        CmabClientHelperAndroid helper = new CmabClientHelperAndroid();
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("66", 25);
+        attributes.put("77", "US");
+
+        String json = helper.buildRequestJson("user123", "exp1", attributes, "uuid-123");
+
+        assertTrue(json.contains("\"id\":\"66\""));
+        assertTrue(json.contains("\"id\":\"77\""));
+        assertTrue(json.contains("\"type\":\"custom_attribute\""));
+        assertFalse(json.contains("\"id\":\"age\""));
+        assertFalse(json.contains("\"id\":\"country\""));
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
     build_tools_version = "35.0.0"
     min_sdk_version = 21
     target_sdk_version = 35
-    java_core_ver = "4.4.2--NEED-UPDATE"
+    java_core_ver = "4.4.2"
     android_logger_ver = "1.3.6"
     jacksonversion= "2.11.2"
     annotations_ver = "1.2.0"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2021, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2021, 2026, Optimizely, Inc. and contributors              *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -97,7 +97,7 @@ ext {
     build_tools_version = "35.0.0"
     min_sdk_version = 21
     target_sdk_version = 35
-    java_core_ver = "4.4.2"
+    java_core_ver = "4.4.2--NEED-UPDATE"
     android_logger_ver = "1.3.6"
     jacksonversion= "2.11.2"
     annotations_ver = "1.2.0"


### PR DESCRIPTION
## Summary

The CMAB prediction request payload requires the attribute ID in the `id` field, but the attribute key was being sent instead. The Android SDK inherits CMAB logic from the Java SDK core-api, which already contains this fix. This PR bumps the Java core dependency version and updates tests to validate attribute ID usage.

## Changes
- Bumped Java SDK core dependency to pick up the attribute ID fix from core-api
- Updated CMAB client test attributes to use ID-based keys instead of key-based keys
- Added test verifying the JSON request payload uses attribute IDs

## Jira Ticket
[FSSDK-12750](https://optimizely-ext.atlassian.net/browse/FSSDK-12750)

[FSSDK-12750]: https://optimizely-ext.atlassian.net/browse/FSSDK-12750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ