### PR TITLE
[FSSDK-12872] Prepare for release android-sdk v5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Optimizely Android X SDK Changelog
 
+## 5.3.0
+July 8, 2026
+
+### New Features
+
+**Local Holdouts**: Added support for Local Holdouts, enabling holdout experiments
+to be scoped to specific feature flags rather than applied globally.
+Local Holdouts let you measure the true incremental impact of individual features
+by holding out a subset of users from specific rollouts while still serving them other experiences.
+See [Holdouts docs](https://support.optimizely.com/hc/en-us/articles/38941939408269-Global-holdouts) for more information.
+
+### Fixes
+
+- Use attribute id instead of key for CMAB prediction requests
+- Normalize decision event campaign_id, variation_id, and entity_id
+
+### Dependency Updates
+
+- Upgrade dependency to [Java SDK 4.5.0](https://github.com/optimizely/java-sdk/releases/tag/4.5.0)
+
 ## 5.2.1
 May 29, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,12 @@ to be scoped to specific feature flags rather than applied globally.
 Local Holdouts let you measure the true incremental impact of individual features
 by holding out a subset of users from specific rollouts while still serving them other experiences.
 See [Holdouts docs](https://support.optimizely.com/hc/en-us/articles/38941939408269-Global-holdouts) for more information.
+- Upgrade dependency to [Java SDK 4.5.0](https://github.com/optimizely/java-sdk/releases/tag/4.5.0)
 
 ### Fixes
 
 - Use attribute id instead of key for CMAB prediction requests
 - Normalize decision event campaign_id, variation_id, and entity_id
-
-### Dependency Updates
-
-- Upgrade dependency to [Java SDK 4.5.0](https://github.com/optimizely/java-sdk/releases/tag/4.5.0)
 
 ## 5.2.1
 May 29, 2026

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.optimizely.ab:android-sdk:5.2.1'
+	implementation 'com.optimizely.ab:android-sdk:5.3.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
     build_tools_version = "35.0.0"
     min_sdk_version = 21
     target_sdk_version = 35
-    java_core_ver = "4.4.2"
+    java_core_ver = "4.5.0"
     android_logger_ver = "1.3.6"
     jacksonversion= "2.11.2"
     annotations_ver = "1.2.0"


### PR DESCRIPTION
## Summary
- Bump java_core_ver from 4.4.2 to 4.5.0 (Local Holdouts, CMAB fixes)
- Update CHANGELOG with 5.3.0 entry
- Update README dependency version to 5.3.0
## Issues
[FSSDK-12872](https://optimizely-ext.atlassian.net/browse/FSSDK-12872)


[FSSDK-12872]: https://optimizely-ext.atlassian.net/browse/FSSDK-12872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ