### PR TITLE
[FSSDK-12682] Fix Jackson serializer crash caused by R8 obfuscation

### DIFF
--- a/proguard-rules.txt
+++ b/proguard-rules.txt
@@ -40,6 +40,17 @@
 -dontwarn com.fasterxml.jackson.**
 -dontwarn org.json.**
 
+# Keep Jackson naming strategy fields accessed via reflection by the Java SDK core-api
+# (DefaultJsonSerializer → JacksonSerializer → getSnakeCaseStrategy).
+# Without this, R8 obfuscates the field names, causing NoClassDefFoundError at runtime
+# when Jackson is on the classpath.
+-keepclassmembers class com.fasterxml.jackson.databind.PropertyNamingStrategies {
+    public static *;
+}
+-keepclassmembers class com.fasterxml.jackson.databind.PropertyNamingStrategy {
+    public static *;
+}
+
 # Annotations
 -dontwarn javax.annotation.**
 


### PR DESCRIPTION
## Summary
- Add consumer ProGuard rules to keep Jackson `PropertyNamingStrategies` and `PropertyNamingStrategy` static field names from being obfuscated by R8

The core-api's `JacksonSerializer.getSnakeCaseStrategy()` uses reflection (`Class.getField("SNAKE_CASE")`) to look up Jackson naming strategy fields. When an app includes Jackson on its classpath and R8 obfuscates those field names, the reflection lookup fails with `NoSuchFieldException`, which crashes the `DefaultJsonSerializer.LazyHolder` static initializer. All subsequent calls to `DefaultJsonSerializer.getInstance()` then throw `NoClassDefFoundError`, preventing any event dispatch (impressions and conversions).

Since `proguard-rules.txt` is already configured as `consumerProguardFiles`, these rules are automatically merged into any app that depends on the SDK — no manual ProGuard configuration required by customers.

Both `PropertyNamingStrategies` (Jackson 2.12+) and `PropertyNamingStrategy` (Jackson 2.11 and earlier) are covered, matching the two-tier reflection fallback in `JacksonSerializer`.

## Test plan
- [ ] Build an app with Jackson on the classpath and R8 minification enabled
- [ ] Verify `DefaultJsonSerializer` initializes without `NoClassDefFoundError`
- [ ] Verify event dispatch (impressions and conversions) works through the default SDK path
- [ ] Verify no regression when Jackson is NOT on the classpath (Gson fallback still works)

## Issues
- FSSDK-12682
- Related: BUG-8620